### PR TITLE
Add a shell wrapper for Greengrass CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 This module is the stand-alone CLI associated with aws-greengrass-kernel
 
+## Installation
+
+Run the following commands to install and use AWS Greengrass CLI:
+```
+$ mvn install
+$ cd $YOUR_INSTALL_ROOT; unzip $PKG_ROOT/target/evergreen-cli-1.0-SNAPSHOT.zip; cd evergreen-cli-1.0-SNAPSHOT;
+$ source install.sh
+$ greengrass-cli help
+```
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+if [ "$(uname)" != "Darwin" ]; then
+    echo "Setting up auto-complete for Greengrass CLI."
+    # Autocomplete is a feature provided by picocli, which is currently NOT supported on Mac https://github.com/remkop/picocli/issues/396
+
+    if [ -n "$ZSH_VERSION" ]; then
+        echo "Allow zsh to read bash completion specifications and functions"
+        autoload -U +X compinit && compinit
+        autoload -U +X bashcompinit && bashcompinit
+    fi
+
+    echo "Source the bash completion script"
+    source $PWD/cli_completion.sh
+fi
+
+ln -fs $PWD/bin/greengrass-cli /usr/local/bin/greengrass-cli || sudo ln -fs $PWD/bin/greengrass-cli /usr/local/bin/greengrass-cli
+echo "Start using greengrass-cli"

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,52 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-autocompletion-script</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>java</executable>
+                    <arguments>
+                        <argument>-Dpicocli.autocomplete.systemExitOnError</argument>
+                        <argument>-cp</argument>
+                        <classpath/>
+                        <argument>picocli.AutoComplete</argument>
+                        <argument>--force</argument><!-- overwrite if exists -->
+                        <argument>--completionScript</argument>
+                        <argument>${project.build.directory}/cli_completion.sh</argument>
+                        <argument>com.aws.iot.evergreen.cli.CLI</argument>
+                        <argument>-n</argument>
+                        <argument>greengrass-cli</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <properties>

--- a/src/bin/greengrass-cli
+++ b/src/bin/greengrass-cli
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+findGreengrassCLIHome() {
+    local source="${BASH_SOURCE[0]}"
+    while [ -h "$source" ] ; do
+        local linked="$(readlink "$source")"
+        local dir="$(cd -P $(dirname "$source") && cd -P $(dirname "$linked") && pwd)"
+        source="$dir/$(basename "$linked")"
+    done
+    (cd -P "$(dirname "$source")/.." && pwd)
+}
+
+CLI_HOME="$(findGreengrassCLIHome)"
+
+if [ -z "$JAVA_HOME" ] ; then
+  JAVACMD=`which java`
+else
+  JAVACMD="$JAVA_HOME/bin/java"
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "The JAVA_HOME environment variable is not defined correctly" >&2
+  echo "This environment variable is needed to run this program" >&2
+  echo "NB: JAVA_HOME should point to a JDK not a JRE" >&2
+  exit 1
+fi
+
+[ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx256M -Xms32M"
+
+declare -a java_args
+declare -a cli_args
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -D*)
+      java_args=("${java_args[@]}" "$1")
+      shift
+      ;;
+    -J*)
+      java_args=("${java_args[@]}" "${1:2}")
+      shift
+      ;;
+    *)
+      cli_args=("${cli_args[@]}" "$1")
+      shift
+      ;;
+  esac
+done
+
+CLI_JAR="${CLI_HOME}/lib/evergreen-cli-1.0-SNAPSHOT.jar:${CLI_HOME}/lib/picocli-4.0.4.jar"
+CLI_LAUNCHER=com.aws.iot.evergreen.cli.CLI
+
+"$JAVACMD" $JAVA_OPTS "${java_args[@]}" -classpath "${CLI_JAR}" ${CLI_LAUNCHER} "${cli_args[@]}"

--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -1,0 +1,38 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.artifactId}-${project.version}.jar</source>
+            <outputDirectory>lib</outputDirectory>
+        </file>
+        <file>
+            <source>${project.build.directory}/cli_completion.sh</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/install.sh</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+    </files>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <excludes>
+                <exclude>${project.groupId}:${project.artifactId}:jar:*</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
*Description of changes:*
1. Add a script for `greengrass-cli` executable.
1. Add a build step to generate Bash Completion Script, following [picocli Autocomplete doc](https://picocli.info/autocomplete.html#_maven_example).
   1. Autocomplete works on Linux, but currently not on Mac. See [open issue](https://github.com/remkop/picocli/issues/396)
1. Add a build step to assemble a zip file for distribution
1. Follow the README to install greengrass-cli. The scripts are not very robust at this point.

Directory layout of the zip distribution file
```
evergreen-cli-1.0-SNAPSHOT/
├── bin
│   └── greengrass-cli
├── cli_completion.sh
├── install.sh
└── lib
    ├── evergreen-cli-1.0-SNAPSHOT.jar
    └── picocli-4.0.4.jar

2 directories, 5 files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
