### PR TITLE
Add maven settings file so we can deploy to S3 repo

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>evergreen-dev-snapshot</id>
+            <username>${access-key-id}</username>
+            <password>${access-key-secret}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
The maven deploy command requires a server.
This is copied from the aws-greengrass-kernel project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
