### PR TITLE
Clean up Java arguments in CLI wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/zip.xml</descriptor>
                             </descriptors>
-                        </configuration>                    </execution>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/src/bin/greengrass-cli
+++ b/src/bin/greengrass-cli
@@ -18,36 +18,7 @@ else
   JAVACMD="$JAVA_HOME/bin/java"
 fi
 
-if [ ! -x "$JAVACMD" ] ; then
-  echo "The JAVA_HOME environment variable is not defined correctly" >&2
-  echo "This environment variable is needed to run this program" >&2
-  echo "NB: JAVA_HOME should point to a JDK not a JRE" >&2
-  exit 1
-fi
-
-[ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx256M -Xms32M"
-
-declare -a java_args
-declare -a cli_args
-
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -D*)
-      java_args=("${java_args[@]}" "$1")
-      shift
-      ;;
-    -J*)
-      java_args=("${java_args[@]}" "${1:2}")
-      shift
-      ;;
-    *)
-      cli_args=("${cli_args[@]}" "$1")
-      shift
-      ;;
-  esac
-done
-
 CLI_JAR="${CLI_HOME}/lib/evergreen-cli-1.0-SNAPSHOT.jar:${CLI_HOME}/lib/picocli-4.0.4.jar"
 CLI_LAUNCHER=com.aws.iot.evergreen.cli.CLI
 
-"$JAVACMD" $JAVA_OPTS "${java_args[@]}" -classpath "${CLI_JAR}" ${CLI_LAUNCHER} "${cli_args[@]}"
+"${JAVACMD:=java}" -classpath "${CLI_JAR}" ${CLI_LAUNCHER} "$@"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Address comments from https://github.com/aws/aws-greengrass-cli/pull/3
1. Fix format in pom.xml.
1. Clean up unused JAVA_OPTS and parameters in shell wrapper.
1. Remove the incorrect information that JDK is required instead of only JRE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
