### PR TITLE
Typo fix in CLI message properties

### DIFF
--- a/src/main/resources/com/aws/iot/evergreen/cli/CLI_messages.properties
+++ b/src/main/resources/com/aws/iot/evergreen/cli/CLI_messages.properties
@@ -25,9 +25,9 @@ cli.component.update.merge=The name and version for the target component(s) you 
   <name>=<version>, such as HelloWorld=1.0.0. Can be multiple.
 cli.component.update.remove=The name of the target component(s) you want to remove. Example: HelloWorld. Can be \
   multiple.
-cli.component.update.recipeDir=Directory containing recipe fies. The file name format is: <Name>-<Version>.yaml, such \
+cli.component.update.recipeDir=Directory containing recipe files. The file name format is: <Name>-<Version>.yaml, such \
   as HelloWorld-1.0.0.yaml.
-cli.component.update.artifactDir=Directory containing artifact fies. Directory should follow the structure: \
+cli.component.update.artifactDir=Directory containing artifact files. Directory should follow the structure: \
   /<Name>/<Version>/<artifacts>.
 cli.component.update.param=Runtime parameters. Format: <Component>.<Key>=<Value>. Example: HelloWorld.Port=8080. Can \
   be multiple.


### PR DESCRIPTION
*Description of changes:*
Minor fix of a typo in `CLI_messages.properties`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
