### PR TITLE
Typo fix in log tool documentation

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/cli/util/logs/README.md
+++ b/src/main/java/com/aws/iot/evergreen/cli/util/logs/README.md
@@ -22,7 +22,7 @@ Type ``greengrass-cli logs help`` or ``greengrass-cli logs help <command>`` for 
 $ greengrass-cli logs get [--log-dir <log-directory> ...] [--log-file <file-path> ...]
                           [--time-window "beginTime","endTime" ...]
                           [--filter "regex","key"="val" ...]
-                          [--follow]
+                          [--follow] [--verbose] [--no-color]
 $ greengrass-cli logs list-log-files --log-dir <log-directory> ...
 ```
 
@@ -146,10 +146,10 @@ To stop the log tool, the user can either terminates the program manually in com
 $ greengreass-cli logs get --time-window ,+5min --log-dir ~/.evergreen/ --follow
 ```
 ### Simplified Output
-Currently two boolean options are supported to control output formats: ``--remove-color`` and ``--verbose``.
+Currently two boolean options are supported to control output formats: ``--no-color`` and ``--verbose``.
 By default, log tool outputs in a simplified format and adds highlight to all filtered keywords, regex,
  and key-value pairs. Default highlight is red and bold.
 
-If input ``--remove-color``, highlight will be removed.
+If input ``--no-color``, highlight will be removed.
 
 If input ``--verbose``, the log tool will output verbose messages.

--- a/src/main/resources/com/aws/iot/evergreen/cli/CLI_messages.properties
+++ b/src/main/resources/com/aws/iot/evergreen/cli/CLI_messages.properties
@@ -46,5 +46,5 @@ cli.logs.get.time-window=Filter log information with provided begin time and end
   Support input by exact timestamps and relative offsets. Refer to user guide for specific timestamp formats it supports. \
   Support multiple time windows.
 cli.logs.get.verbose=Verbose output. Print all fields from log message.
-cli.logs.get.remove-color=Remove color coding. Default color coding is bold and red. Support only unix-like terminal \
+cli.logs.get.no-color=Remove color coding. Default color coding is bold and red. Support only unix-like terminal \
   since it uses ANSI escape sequence.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Minor fix of typos in `CLI_messages.properties` and `README.md`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
