### PR TITLE
Rename paramaeter for Thing Group name from groupId to group-name.

### DIFF
--- a/src/main/java/com/aws/greengrass/cli/commands/ComponentCommand.java
+++ b/src/main/java/com/aws/greengrass/cli/commands/ComponentCommand.java
@@ -54,7 +54,7 @@ public class ComponentCommand extends BaseCommand {
     public int deploy
     (@CommandLine.Option(names = {"-m", "--merge"}, paramLabel = "Component and version") Map<String, String> componentsToMerge,
      @CommandLine.Option(names = {"--remove"}, paramLabel = "Component Names") List<String> componentsToRemove,
-     @CommandLine.Option(names = {"-g", "--groupId"}, paramLabel = "group Id") String groupId,
+     @CommandLine.Option(names = {"-g", "--group-name"}, paramLabel = "IoT Thing Group Name") String groupName,
      @CommandLine.Option(names = {"-r", "--recipeDir"}, paramLabel = "Recipe Folder Path") String recipeDir,
      @CommandLine.Option(names = {"-a", "--artifactDir"}, paramLabel = "Artifacts Folder Path") String artifactDir,
      @CommandLine.Option(names = {"-p", "--param"}, paramLabel = "Runtime parameters") Map<String, String> parameters)
@@ -65,7 +65,7 @@ public class ComponentCommand extends BaseCommand {
             kernelAdapterIpc.updateRecipesAndArtifacts(recipeDir, artifactDir);
         }
         CreateLocalDeploymentRequest createLocalDeploymentRequest = CreateLocalDeploymentRequest.builder()
-                .groupName(groupId)
+                .groupName(groupName)
                 .componentToConfiguration(componentNameToConfig)
                 .rootComponentVersionsToAdd(componentsToMerge)
                 .rootComponentsToRemove(componentsToRemove)

--- a/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -26,7 +26,7 @@ public class DeploymentCommand extends BaseCommand {
     public int create
     (@CommandLine.Option(names = {"-m", "--merge"}, paramLabel = "Component and version") Map<String, String> componentsToMerge,
      @CommandLine.Option(names = {"--remove"}, paramLabel = "Component Names") List<String> componentsToRemove,
-     @CommandLine.Option(names = {"-g", "--groupId"}, paramLabel = "group Id") String groupId,
+     @CommandLine.Option(names = {"-g", "--group-name"}, paramLabel = "IoT Thing Group Name") String groupName,
      @CommandLine.Option(names = {"-r", "--recipeDir"}, paramLabel = "Recipe Folder Path") String recipeDir,
      @CommandLine.Option(names = {"-a", "--artifactDir"}, paramLabel = "Artifacts Folder Path") String artifactDir,
      @CommandLine.Option(names = {"-p", "--param"}, paramLabel = "Runtime parameters") Map<String, String> parameters)
@@ -37,7 +37,7 @@ public class DeploymentCommand extends BaseCommand {
             kernelAdapterIpc.updateRecipesAndArtifacts(recipeDir, artifactDir);
         }
         CreateLocalDeploymentRequest createLocalDeploymentRequest = CreateLocalDeploymentRequest.builder()
-                .groupName(groupId)
+                .groupName(groupName)
                 .componentToConfiguration(componentNameToConfig)
                 .rootComponentVersionsToAdd(componentsToMerge)
                 .rootComponentsToRemove(componentsToRemove)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Group Id was not the current parameter for the command. We need to send the group name. Changing the parameter name to group-name to keep convention as https://docs.aws.amazon.com/cli/latest/reference/iot/create-thing-group.html 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
