### PR TITLE
Allow deployment create to take a JSON file

### DIFF
--- a/src/main/java/com/aws/greengrass/cli/commands/ComponentCommand.java
+++ b/src/main/java/com/aws/greengrass/cli/commands/ComponentCommand.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 @CommandLine.Command(name = "component", resourceBundle = "com.aws.greengrass.cli.CLI_messages",
-        subcommands = CommandLine.HelpCommand.class)
+        subcommands = CommandLine.HelpCommand.class, mixinStandardHelpOptions = true)
 public class ComponentCommand extends BaseCommand {
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -33,7 +33,7 @@ public class ComponentCommand extends BaseCommand {
         this.nucleusAdapterIpc = nucleusAdapterIpc;
     }
 
-    @CommandLine.Command(name = "restart")
+    @CommandLine.Command(name = "restart", mixinStandardHelpOptions = true)
     public int restart(@CommandLine.Option(names = {"-n", "--names"}, paramLabel = "component names separated by comma", descriptionKey = "names", required = true) String names)
             throws CliIpcClientException, GenericCliIpcServerException {
         String[] componentNames = names.split(" *[&,]+ *");
@@ -43,7 +43,7 @@ public class ComponentCommand extends BaseCommand {
         return 0;
     }
 
-    @CommandLine.Command(name = "stop")
+    @CommandLine.Command(name = "stop", mixinStandardHelpOptions = true)
     public int stop(@CommandLine.Option(names = {"-n", "--names"}, paramLabel = "component names separated by comma", descriptionKey = "names", required = true) String names)
             throws CliIpcClientException, GenericCliIpcServerException {
         String[] componentNames = names.split(" *[&,]+ *");
@@ -54,7 +54,7 @@ public class ComponentCommand extends BaseCommand {
     }
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
-    @CommandLine.Command(name = "list",
+    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true,
             description = "Prints root level components names, component information and runtime parameters")
     public int list() throws CliIpcClientException, GenericCliIpcServerException, JsonProcessingException {
         List<ComponentDetails> componentDetails = nucleusAdapterIpc.listComponents();
@@ -66,7 +66,7 @@ public class ComponentCommand extends BaseCommand {
     }
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
-    @CommandLine.Command(name = "details")
+    @CommandLine.Command(name = "details", mixinStandardHelpOptions = true)
     public int details(@CommandLine.Option(names = {"-n", "--name"}, paramLabel = " component name", descriptionKey = "name", required = true) String componentName)
             throws CliIpcClientException, GenericCliIpcServerException, JsonProcessingException {
         ComponentDetails componentDetails = nucleusAdapterIpc.getComponentDetails(componentName);

--- a/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -14,14 +14,20 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.cli.adapter.impl.NucleusAdapterIpcClientImpl.deTilde;
 import static com.aws.greengrass.cli.commands.ComponentCommand.convertParameters;
 
 @CommandLine.Command(name = "deployment", resourceBundle = "com.aws.greengrass.cli.CLI_messages",
-        subcommands = CommandLine.HelpCommand.class)
+        subcommands = CommandLine.HelpCommand.class, mixinStandardHelpOptions = true)
 public class DeploymentCommand extends BaseCommand {
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -36,7 +42,8 @@ public class DeploymentCommand extends BaseCommand {
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
     @CommandLine.Command(name = "create",
-            description = "Create local deployment with provided recipes, artifacts, and runtime parameters")
+            description = "Create local deployment with provided recipes, artifacts, and runtime parameters",
+            mixinStandardHelpOptions = true)
     public int create
     (@CommandLine.Option(names = {"-m", "--merge"}, paramLabel = "Component and version") Map<String, String> componentsToMerge,
      @CommandLine.Option(names = {"--remove"}, paramLabel = "Component Names") List<String> componentsToRemove,
@@ -45,12 +52,31 @@ public class DeploymentCommand extends BaseCommand {
      @CommandLine.Option(names = {"-a", "--artifactDir"}, paramLabel = "Artifacts Folder Path") String artifactDir,
      @CommandLine.Option(names = {"-p", "--param"}, paramLabel = "Runtime parameters") Map<String, String> parameters,
      @CommandLine.Option(names = {"-c", "--update-config"}, paramLabel = "Update configuration") String configUpdate)
-            throws CliIpcClientException, GenericCliIpcServerException, JsonProcessingException {
+            throws CliIpcClientException, GenericCliIpcServerException, IOException {
         // GG_NEEDS_REVIEW: TODO Validate folder exists and folder structure
         Map<String, Map<String, Object>> componentNameToConfig = convertParameters(parameters);
         Map<String, Map<String, Object>> configurationUpdate = null;
         if (configUpdate != null && !configUpdate.isEmpty()) {
-            configurationUpdate = mapper.readValue(configUpdate, Map.class);
+            try {
+                // Try to read JSON from a file if it is a path and the file exists
+                try {
+                    Path filePath = Paths.get(deTilde(configUpdate));
+                    if (Files.exists(filePath)) {
+                        configurationUpdate = mapper.readValue(filePath.toFile(), Map.class);
+                    }
+                } catch (InvalidPathException ignored) {
+                }
+                // If it wasn't a file or a path, then try reading it as a JSON string
+                if (configurationUpdate == null) {
+                    configurationUpdate = mapper.readValue(configUpdate, Map.class);
+                }
+            } catch (JsonProcessingException e) {
+                System.err.println(spec.commandLine().getColorScheme()
+                        .errorText("Update configuration parameter is not a properly formatted JSON "
+                                + "file or a JSON string"));
+                System.err.println(spec.commandLine().getColorScheme().errorText(e.getMessage()));
+                return 1;
+            }
         }
         if (recipeDir != null || artifactDir != null) {
             nucleusAdapterIpc.updateRecipesAndArtifacts(recipeDir, artifactDir);
@@ -69,7 +95,7 @@ public class DeploymentCommand extends BaseCommand {
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
     @CommandLine.Command(name = "status",
-            description = "Retrieve the status of a deployment")
+            description = "Retrieve the status of a deployment", mixinStandardHelpOptions = true)
     public int status(@CommandLine.Option(names = {"-i", "--deploymentId"}, paramLabel = "Deployment Id", required = true) String deploymentId)
             throws CliIpcClientException, GenericCliIpcServerException {
 
@@ -79,7 +105,8 @@ public class DeploymentCommand extends BaseCommand {
     }
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
-    @CommandLine.Command(name = "list", description = "Retrieve the status of local deployments")
+    @CommandLine.Command(name = "list", description = "Retrieve the status of local deployments",
+            mixinStandardHelpOptions = true)
     public int list() throws CliIpcClientException, GenericCliIpcServerException {
         List<LocalDeployment> localDeployments = nucleusAdapterIpc.listLocalDeployments();
         localDeployments.forEach((status) -> System.out.println(status.getDeploymentId() + ": " + status.getStatus()));

--- a/src/main/java/com/aws/greengrass/cli/commands/Logs.java
+++ b/src/main/java/com/aws/greengrass/cli/commands/Logs.java
@@ -22,7 +22,8 @@ import javax.inject.Inject;
 
 import static com.aws.greengrass.cli.adapter.impl.NucleusAdapterIpcClientImpl.deTilde;
 
-@Command(name = "logs", resourceBundle = "com.aws.greengrass.cli.CLI_messages", subcommands = HelpCommand.class)
+@Command(name = "logs", resourceBundle = "com.aws.greengrass.cli.CLI_messages", subcommands = HelpCommand.class,
+        mixinStandardHelpOptions = true)
 public class Logs extends BaseCommand {
 
     private final Aggregation aggregation;
@@ -40,7 +41,7 @@ public class Logs extends BaseCommand {
         this.visualization = visualization;
     }
 
-    @Command(name = "get")
+    @Command(name = "get", mixinStandardHelpOptions = true)
     public int get(@CommandLine.Option(names = {"-lf", "--log-file"}, paramLabel = "Log File Path") String[] logFileArray,
                    @CommandLine.Option(names = {"-ld", "--log-dir"}, paramLabel = "Log Directory Path") String[] logDirArray,
                    @CommandLine.Option(names = {"-t", "--time-window"}, paramLabel = "Time Window") String[] timeWindow,
@@ -88,8 +89,8 @@ public class Logs extends BaseCommand {
         return arr;
     }
 
-    @Command(name = "list-log-files")
-    public void list_log(@CommandLine.Option(names = {"-ld", "--log-dir"}, paramLabel = "Log Directory Path")
+    @Command(name = "list-log-files", mixinStandardHelpOptions = true)
+    public void listLogFiles(@CommandLine.Option(names = {"-ld", "--log-dir"}, paramLabel = "Log Directory Path")
                                  String[] logDir) {
         Set<File> logFileSet = aggregation.listLog(logDir);
         if (!logFileSet.isEmpty()) {
@@ -102,8 +103,8 @@ public class Logs extends BaseCommand {
         LogsUtil.getPrintStream().println("No log file found.");
     }
 
-    @Command(name = "list-keywords")
-    public void list_keywords(@CommandLine.Option(names = {"-s", "--syslog"}, paramLabel = "Syslog Flag") boolean syslog) {
+    @Command(name = "list-keywords", mixinStandardHelpOptions = true)
+    public void listKeywords(@CommandLine.Option(names = {"-s", "--syslog"}, paramLabel = "Syslog Flag") boolean syslog) {
         if (syslog) {
             LogsUtil.getPrintStream().println(new StringBuilder("Here is a list of suggested keywords for syslog: ")
                     .append(System.lineSeparator()).append("priority=$int").append(System.lineSeparator())

--- a/src/main/resources/com/aws/greengrass/cli/CLI_messages.properties
+++ b/src/main/resources/com/aws/greengrass/cli/CLI_messages.properties
@@ -23,6 +23,8 @@ cli.deployment.create.artifactDir=Directory containing artifact files. Directory
 cli.deployment.create.param=Runtime parameters. Format: <Component>:<Key>=<Value>. Example: HelloWorld:Port=8080. Can \
   be multiple.
 cli.deployment.create.groupId=Group the deployment is targeting
+cli.deployment.create.update-config=Configuration update JSON string or JSON file. Format should be {"MERGE": \
+  "componentName": {"key": "value"}, "RESET": ["pathsToReset"]}
 cli.deployment.status.usage.description=Get status of a local deployment using deployment id
 cli.deployment.list.usage.description=List the status of local deployments
 # Log


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds `--help` and `-h` to all commands. Enables `deployment create -c <file>` to take a JSON string _or_ a JSON file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
