### PR TITLE
Using runtime config for presisting local deployments

### DIFF
--- a/server/src/main/java/com/aws/greengrass/cli/CLIService.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIService.java
@@ -137,11 +137,11 @@ public class CLIService extends PluginService {
         greengrassCoreIPCService.setStopComponentHandler((context)
                 -> cliEventStreamAgent.getStopComponentsHandler(context));
         greengrassCoreIPCService.setCreateLocalDeploymentHandler((context)
-                -> cliEventStreamAgent.getCreateLocalDeploymentHandler(context, config));
+                -> cliEventStreamAgent.getCreateLocalDeploymentHandler(context, this.getRuntimeConfig()));
         greengrassCoreIPCService.setGetLocalDeploymentStatusHandler((context)
-                -> cliEventStreamAgent.getGetLocalDeploymentStatusHandler(context, config));
+                -> cliEventStreamAgent.getGetLocalDeploymentStatusHandler(context, this.getRuntimeConfig()));
         greengrassCoreIPCService.setListLocalDeploymentsHandler((context)
-                -> cliEventStreamAgent.getListLocalDeploymentsHandler(context, config));
+                -> cliEventStreamAgent.getListLocalDeploymentsHandler(context, this.getRuntimeConfig()));
         greengrassCoreIPCService.setCreateDebugPasswordHandler((context)
                 -> cliEventStreamAgent.getCreateDebugPasswordHandler(context, config.getRoot()));
     }
@@ -341,7 +341,7 @@ public class CLIService extends PluginService {
 
     @SuppressWarnings("PMD.EmptyIfStmt")
     protected Boolean deploymentStatusChanged(Map<String, Object> deploymentDetails) {
-        cliEventStreamAgent.persistLocalDeployment(config, deploymentDetails);
+        cliEventStreamAgent.persistLocalDeployment(this.getRuntimeConfig(), deploymentDetails);
         return true;
     }
 }

--- a/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
@@ -44,6 +44,7 @@ import static com.aws.greengrass.cli.CLIService.AUTHORIZED_POSIX_GROUPS;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET_FILEPATH;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
@@ -89,6 +90,7 @@ class CLIServiceTest extends GGServiceTestUtil {
     private Topics serviceConfigSpy;
     private Topics cliConfigSpy;
     private Topics privateConfigSpy;
+    private Topics runtimeConfigSpy;
 
     @BeforeEach
     void setup() {
@@ -98,6 +100,7 @@ class CLIServiceTest extends GGServiceTestUtil {
         serviceConfigSpy = spy(Topics.of(context, SERVICES_NAMESPACE_TOPIC, null));
         cliConfigSpy = spy(Topics.of(context, CLI_SERVICE, serviceConfigSpy));
         privateConfigSpy = spy(Topics.of(context, PRIVATE_STORE_NAMESPACE_TOPIC, cliConfigSpy));
+        runtimeConfigSpy = cliConfigSpy.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);
 
         cliService = new CLIService(cliConfigSpy, privateConfigSpy, cliEventStreamAgent,
                 deploymentStatusKeeper, authenticationHandler, kernel, greengrassCoreIPCService);
@@ -224,6 +227,6 @@ class CLIServiceTest extends GGServiceTestUtil {
     void testDeploymentStatusChanged_calls() {
         Map<String, Object> deploymentDetails = new HashMap<>();
         cliService.deploymentStatusChanged(deploymentDetails);
-        verify(cliEventStreamAgent).persistLocalDeployment(cliConfigSpy, deploymentDetails);
+        verify(cliEventStreamAgent).persistLocalDeployment(runtimeConfigSpy, deploymentDetails);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Local deployments get reset upon config merge that happens on a deployment. This is why only the most recent deployment is persisted. 

*Description of changes:*
Storing the local deployment status under runtime config.

*Testing:*
Ran some scenarios of local deployment on cloud desktop and the reproduced issue was fixed. Can now successfully retrieve deployment status, and deployment list

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
