### PR TITLE
Close the files first before deleting the temp directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /nbproject/
 **/*.iml
 **/.DS_Store
+.idea/

--- a/client/src/test/java/com/aws/greengrass/cli/commands/LogsTest.java
+++ b/client/src/test/java/com/aws/greengrass/cli/commands/LogsTest.java
@@ -246,9 +246,9 @@ public class LogsTest {
 
     @AfterEach
     void cleanup() {
-        deleteDir(logDir.toFile());
         printStream.close();
         fileWriter.close();
+        deleteDir(logDir.toFile());
     }
 
     private void runCommandLine(String... args) {

--- a/client/src/test/java/com/aws/greengrass/cli/util/logs/impl/AggregationImplTest.java
+++ b/client/src/test/java/com/aws/greengrass/cli/util/logs/impl/AggregationImplTest.java
@@ -138,18 +138,22 @@ class AggregationImplTest {
     @Test
     void testReadLogMultipleFile() throws IOException, InterruptedException {
         writer.println(logEntry);
+        writer.close();
 
         File logFile2 = logDir.resolve("greengrass_2020_12_01_00_0.log").toFile();
         writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile2));
         writer.println(logEntry2);
+        writer.close();
 
         File logFile3 = logDir.resolve("aws.greengrass.Nucleus_2020_12_01_00_0.log").toFile();
         writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile3));
         writer.println(logEntry3);
+        writer.close();
 
         File logFile4 = logDir.resolve("aws.greengrass.Nucleus_2020_12_01_02_0.log").toFile();
         writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile4));
         writer.println(logEntry4);
+        writer.close();
 
         String[] logFilePath = {logFile.getPath(), logFile2.getPath(), logFile3.getPath(), logFile4.getPath()};
 
@@ -267,8 +271,8 @@ class AggregationImplTest {
     @AfterEach
     void cleanup() {
         aggregation.close();
-        deleteDir(logDir.toFile());
         writer.close();
         errorStream.close();
+        deleteDir(logDir.toFile());
     }
 }

--- a/client/src/test/java/com/aws/greengrass/cli/util/logs/impl/AggregationImplTest.java
+++ b/client/src/test/java/com/aws/greengrass/cli/util/logs/impl/AggregationImplTest.java
@@ -138,22 +138,21 @@ class AggregationImplTest {
     @Test
     void testReadLogMultipleFile() throws IOException, InterruptedException {
         writer.println(logEntry);
-        writer.close();
 
         File logFile2 = logDir.resolve("greengrass_2020_12_01_00_0.log").toFile();
-        writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile2));
-        writer.println(logEntry2);
-        writer.close();
+        try (PrintStream writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile2))) {
+            writer.println(logEntry2);
+        }
 
         File logFile3 = logDir.resolve("aws.greengrass.Nucleus_2020_12_01_00_0.log").toFile();
-        writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile3));
-        writer.println(logEntry3);
-        writer.close();
+        try (PrintStream writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile3))) {
+            writer.println(logEntry3);
+        }
 
         File logFile4 = logDir.resolve("aws.greengrass.Nucleus_2020_12_01_02_0.log").toFile();
-        writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile4));
-        writer.println(logEntry4);
-        writer.close();
+        try (PrintStream writer = TestUtil.createPrintStreamFromOutputStream(new FileOutputStream(logFile4))) {
+            writer.println(logEntry4);
+        }
 
         String[] logFilePath = {logFile.getPath(), logFile2.getPath(), logFile3.getPath(), logFile4.getPath()};
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move the call to delete the temp directory at last.

**Why is this change necessary:**
When running unit tests on Windows, some tests can't delete the temp directory because some files are still open.

**How was this change tested:**
Those unit tests that failed because they can't delete the temp directory are passing now.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
