### PR TITLE
feat(debugpassword): print certificate fingerprint in get-debug-password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -83,12 +83,10 @@
             <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- TODO: Change when Iot Device SDK with greengrass ipc is released publicly-->
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
-            <artifactId>aws-iot-device-sdk-v2</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>aws-iot-device-sdk</artifactId>
+            <version>1.2.10-dev-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/client/src/main/java/com/aws/greengrass/cli/commands/PasswordCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/PasswordCommand.java
@@ -33,5 +33,13 @@ public class PasswordCommand extends BaseCommand {
         System.out.println("Password will expire at: " +
                 DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault())
                         .format(response.getPasswordExpiration()));
+        if (response.getCertificateSignature() != null && !response.getCertificateSignature().isEmpty()) {
+            System.out.println(); // Newline to separate the TLS information + warning
+            System.out.println("Local debug console is configured to use TLS security. Since the certificate is "
+                    + "self-signed you will need to bypass any warnings from your web browser.");
+            System.out.println("Before bypassing the security alerts, verify the certificate SHA256 fingerprint "
+                    + "matches: ");
+            System.out.println(response.getCertificateSignature());
+        }
     }
 }

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -597,6 +597,7 @@ public class CLIEventStreamAgent {
                 ((Topics) config.lookupTopics("_debugPassword").withParentNeedsToKnow(false))
                         .lookup(DEBUG_USERNAME, password, "expiration").withValue(expiration.toEpochMilli());
 
+                response.setCertificateSignature(Coerce.toString(config.find("_certificateFingerprint")));
                 response.setPassword(password);
                 response.setPasswordExpiration(expiration);
                 response.setUsername(DEBUG_USERNAME);

--- a/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
@@ -71,6 +71,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasLength;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -402,6 +403,12 @@ class CLIEventStreamAgentTest {
             assertNotNull(topics.findTopics("_debugPassword", "debug", response.getPassword()));
             assertEquals(response.getPasswordExpiration().toEpochMilli(),
                     Coerce.toLong(topics.find("_debugPassword", "debug", response.getPassword(), "expiration")));
+            assertNull(response.getCertificateSignature());
+
+            topics.lookup("_certificateFingerprint").withValue("ABCD");
+            response =
+                    cliEventStreamAgent.getCreateDebugPasswordHandler(mockContext, topics).handleRequest(request);
+            assertEquals("ABCD", response.getCertificateSignature());
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If there is a certificate fingerprint set, then print that for the user to validate the certificate matches.

**Why is this change necessary:**

**How was this change tested:**
Added test and manually tested.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
