### PR TITLE
fix: provide both sha1 and sha256 certificate hash

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/commands/PasswordCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/PasswordCommand.java
@@ -30,16 +30,21 @@ public class PasswordCommand extends BaseCommand {
         CreateDebugPasswordResponse response = nucleusAdapterIpc.createDebugPassword();
         System.out.println("Username: " + response.getUsername());
         System.out.println("Password: " + response.getPassword());
-        System.out.println("Password will expire at: " +
+        System.out.println("Password expires at: " +
                 DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault())
                         .format(response.getPasswordExpiration()));
-        if (response.getCertificateSignature() != null && !response.getCertificateSignature().isEmpty()) {
+        if (response.getCertificateSHA1Hash() != null || response.getCertificateSHA256Hash() != null) {
             System.out.println(); // Newline to separate the TLS information + warning
-            System.out.println("Local debug console is configured to use TLS security. Since the certificate is "
-                    + "self-signed you will need to bypass any warnings from your web browser.");
-            System.out.println("Before bypassing the security alerts, verify the certificate SHA256 fingerprint "
-                    + "matches: ");
-            System.out.println(response.getCertificateSignature());
+            System.out.println("The local debug console is configured to use TLS security. The certificate is "
+                    + "self-signed so you will need to bypass your web browser's security warnings to open the console.");
+            System.out.println("Before you bypass the security warning, verify that the certificate fingerprint "
+                    + "matches one of the following fingerprints.");
+            if (response.getCertificateSHA256Hash() != null) {
+                System.out.println("SHA-256: " + response.getCertificateSHA256Hash());
+            }
+            if (response.getCertificateSHA1Hash() != null) {
+                System.out.println("SHA-1: " + response.getCertificateSHA1Hash());
+            }
         }
     }
 }

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -108,6 +108,7 @@ public class CLIEventStreamAgent {
     private static final int DEBUG_PASSWORD_LENGTH_REQUIREMENT = 32;
     private static final String DEBUG_USERNAME = "debug";
     private static final Duration DEBUG_PASSWORD_EXPIRATION = Duration.ofHours(8);
+    protected static final String CERT_FINGERPRINT_NAMESPACE = "_certificateFingerprint";
 
     @Inject
     private Kernel kernel;
@@ -597,7 +598,8 @@ public class CLIEventStreamAgent {
                 ((Topics) config.lookupTopics("_debugPassword").withParentNeedsToKnow(false))
                         .lookup(DEBUG_USERNAME, password, "expiration").withValue(expiration.toEpochMilli());
 
-                response.setCertificateSignature(Coerce.toString(config.find("_certificateFingerprint")));
+                response.setCertificateSHA1Hash(Coerce.toString(config.find(CERT_FINGERPRINT_NAMESPACE, "SHA-1")));
+                response.setCertificateSHA256Hash(Coerce.toString(config.find(CERT_FINGERPRINT_NAMESPACE, "SHA-256")));
                 response.setPassword(password);
                 response.setPasswordExpiration(expiration);
                 response.setUsername(DEBUG_USERNAME);

--- a/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
@@ -403,12 +403,15 @@ class CLIEventStreamAgentTest {
             assertNotNull(topics.findTopics("_debugPassword", "debug", response.getPassword()));
             assertEquals(response.getPasswordExpiration().toEpochMilli(),
                     Coerce.toLong(topics.find("_debugPassword", "debug", response.getPassword(), "expiration")));
-            assertNull(response.getCertificateSignature());
+            assertNull(response.getCertificateSHA256Hash());
+            assertNull(response.getCertificateSHA1Hash());
 
-            topics.lookup("_certificateFingerprint").withValue("ABCD");
+            topics.lookup("_certificateFingerprint", "SHA-1").withValue("ABCD");
+            topics.lookup("_certificateFingerprint", "SHA-256").withValue("ABCDE");
             response =
                     cliEventStreamAgent.getCreateDebugPasswordHandler(mockContext, topics).handleRequest(request);
-            assertEquals("ABCD", response.getCertificateSignature());
+            assertEquals("ABCD", response.getCertificateSHA1Hash());
+            assertEquals("ABCDE", response.getCertificateSHA256Hash());
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Windows doesn't show the certificate hash using SHA-256, only SHA-1. So we now provide both SHA-1 and SHA-256.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
