### PR TITLE
feat(windows): add install.cmd batch script

### DIFF
--- a/client/.license/style.xml
+++ b/client/.license/style.xml
@@ -16,4 +16,14 @@
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
     </java_style>
+    <batch>
+        <firstLine>@REM -------------------------------</firstLine>
+        <beforeEachLine>@REM </beforeEachLine>
+        <endLine>@REM -------------------------------</endLine>
+        <firstLineDetectionPattern>@REM(\\s|\\t)*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>@REM(\\s|\\t)*.*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </batch>
 </additionalHeaders>

--- a/client/install.cmd
+++ b/client/install.cmd
@@ -1,0 +1,32 @@
+@REM -------------------------------
+@REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM -------------------------------
+@echo off
+SETLOCAL
+@REM Check if greengrass-cli is already a recognized command, if so, exit, we don't need to install
+FOR /F "delims=" %%A IN ('WHERE greengrass-cli 2^>NUL') DO SET CLI_PATH=%%A
+IF NOT "%CLI_PATH%"=="" (
+    ECHO Greengrass-cli is already installed
+    EXIT /B 0   
+)
+
+@REM Return is always going to be as follows
+@REM Path REG_EXPAND_SZ <Path/data/>
+@REM But the path data might have spaces in the directory names so 2* will tokenize everything after the first 2 tokens into the last one
+FOR /F "tokens=2*" %%a IN ('REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path') DO SET SYS_PATH=%%~b
+
+@REM Get registry type (should be REG_EXPAND_SZ)
+FOR /F "tokens=1,2" %%a IN ('REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path') DO SET REG_TYPE=%%b
+
+SET DIR=%~dp0
+SET GG_BIN=%DIR%bin
+
+SET SYS_PATH=%GG_BIN%;%SYS_PATH%
+
+@REM Add /greengrass/v2/bin to System PATH via registry
+REG ADD "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path /T %REG_TYPE% /D "%SYS_PATH%" /F
+
+@REM Add /greengrass/v2/bin to PATH currently to avoid having to restart for the registry update to take effect
+ENDLOCAL & SET "PATH=%GG_BIN%;%PATH%"
+ECHO Start using greengrass-cli

--- a/client/src/main/assembly/zip.xml
+++ b/client/src/main/assembly/zip.xml
@@ -32,5 +32,9 @@
             <source>${project.basedir}/install.sh</source>
             <outputDirectory>/</outputDirectory>
         </file>
+        <file>
+            <source>${project.basedir}/install.cmd</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
     </files>
 </assembly>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added an **install.cmd** script that will allow Windows users to use the greengrass-cli without having to fully qualify the path to the script.
**install.cmd** does this by adding the _<CLI_PACKAGE_PATH>\bin_ to the System PATH registry. Normally, changes to the registry PATH variable are not recognized until the user refreshes their environment variables (this can be done in a few ways). To avoid having to do that, the final step in the code is to set the volatile session PATH variable with the new PATH as well (line 31).

**Why system PATH and not user PATH?**
Feature parity with _/usr/local/bin_ having default permissions _drwxr-xr-x_

**Why is this change necessary:**
On Unix devices, users can run **install.sh** and afterwards, they are able to type `greengrass-cli` into their terminal and start using the greengrass-cli.

This is the end, expected behavior for Windows.

**How was this change tested:**
1. Ran `mvn package` and unzipped the resulting zip (had to run with tests disabled because unrelated tests were failing on my Windows instance)
2. Ran `install.cmd` from <UNZIPPED_DIR>/cliclient-2.1.0-SNAPSHOT
3. Ran `greengrass-cli -h` from other directories
4. Verified I saw the expected _help_ instructions

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
