### PR TITLE
fix(windows): fix AggregationImplTest

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
@@ -300,22 +300,19 @@ public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
 
     }
 
-    public static String deTilde(String path) {
-        if (path == null) {
-            return path;
-        }
-        if (path.isEmpty()) {
-            return path;
+    public static Optional<Path> deTilde(String path) {
+        if (path == null || path.isEmpty()) {
+            return Optional.empty();
         }
         if (path.startsWith(HOME_DIR_PREFIX)) {
-            return Paths.get(System.getProperty("user.home")).resolve(path.substring(HOME_DIR_PREFIX.length()))
-                    .toAbsolutePath().toString();
+            return Optional.of(Paths.get(System.getProperty("user.home")).resolve(path.substring(HOME_DIR_PREFIX.length()))
+                    .toAbsolutePath());
         }
-        return Paths.get(path).toAbsolutePath().toString();
+        return Optional.of(Paths.get(path).toAbsolutePath());
     }
 
     private byte[] loadCliIpcInfo(String ggcRootPath) throws IOException {
-        Path directory = Paths.get(deTilde(ggcRootPath)).resolve(CLI_IPC_INFO_DIRECTORY).normalize();
+        Path directory = deTilde(ggcRootPath).orElse(Paths.get("")).resolve(CLI_IPC_INFO_DIRECTORY).normalize();
 
         IOException e = new IOException("Not able to find auth information in directory: " + directory +
                 ". Please run CLI as authorized user or group.");

--- a/client/src/main/java/com/aws/greengrass/cli/util/logs/Aggregation.java
+++ b/client/src/main/java/com/aws/greengrass/cli/util/logs/Aggregation.java
@@ -6,14 +6,16 @@
 package com.aws.greengrass.cli.util.logs;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 public interface Aggregation {
     void configure(boolean follow, Filter filter, int before, int after, int max);
 
-    LogQueue readLog(String[] logFileArray, String[] logDirArray);
+    LogQueue readLog(List<Path> logFileList, List<Path> logDirList);
 
-    Set<File> listLog(String[] logDir);
+    Set<File> listLog(List<Path> logDirList);
 
     Boolean isAlive();
 

--- a/client/src/main/java/com/aws/greengrass/cli/util/logs/FileReader.java
+++ b/client/src/main/java/com/aws/greengrass/cli/util/logs/FileReader.java
@@ -94,7 +94,7 @@ public class FileReader implements Runnable {
                     }
                 }
             } catch (FileNotFoundException e) {
-                LogsUtil.getErrorStream().println("Can not find file: " + file);
+                LogsUtil.getErrorStream().println("Cannot find file: " + file);
             } catch (IOException e) {
                 LogsUtil.getErrorStream().println(file + "readLine() failed.");
                 LogsUtil.getErrorStream().println(e.getMessage());

--- a/client/src/test/java/com/aws/greengrass/cli/commands/DeploymentCommandTest.java
+++ b/client/src/test/java/com/aws/greengrass/cli/commands/DeploymentCommandTest.java
@@ -56,7 +56,7 @@ class DeploymentCommandTest {
     void GIVEN_WHEN_artifact_dir_is_provided_THEN_request_contains_provided_artifact_dir() {
         int exitCode = runCommandLine("deployment", "create", "--artifactDir", ARTIFACT_FOLDER_PATH_STR);
         CreateLocalDeploymentRequest request = new CreateLocalDeploymentRequest();
-        request.setArtifactsDirectoryPath(deTilde(ARTIFACT_FOLDER_PATH_STR));
+        request.setArtifactsDirectoryPath(deTilde(ARTIFACT_FOLDER_PATH_STR).get().toString());
         verify(nucleusAdapteripc).createLocalDeployment(request);
         assertThat(exitCode, is(0));
     }
@@ -66,7 +66,7 @@ class DeploymentCommandTest {
         int exitCode = runCommandLine("deployment", "create", "-a", ARTIFACT_FOLDER_PATH_STR);
 
         CreateLocalDeploymentRequest request = new CreateLocalDeploymentRequest();
-        request.setArtifactsDirectoryPath(deTilde(ARTIFACT_FOLDER_PATH_STR));
+        request.setArtifactsDirectoryPath(deTilde(ARTIFACT_FOLDER_PATH_STR).get().toString());
         verify(nucleusAdapteripc).createLocalDeployment(request);
         assertThat(exitCode, is(0));
     }
@@ -84,7 +84,7 @@ class DeploymentCommandTest {
     void GIVEN_WHEN_recipe_dir_is_provided_THEN_request_contains_provided_recipe_dir() {
         int exitCode = runCommandLine("deployment", "create", "--recipeDir", RECIPE_FOLDER_PATH_STR);
         CreateLocalDeploymentRequest request = new CreateLocalDeploymentRequest();
-        request.setRecipeDirectoryPath(deTilde(RECIPE_FOLDER_PATH_STR));
+        request.setRecipeDirectoryPath(deTilde(RECIPE_FOLDER_PATH_STR).get().toString());
         verify(nucleusAdapteripc).createLocalDeployment(request);
         assertThat(exitCode, is(0));
     }
@@ -93,7 +93,7 @@ class DeploymentCommandTest {
     void GIVEN_WHEN_recipe_dir_is_provided_with_short_name_THEN_request_contains_provided_recipe_dir() {
         int exitCode = runCommandLine("deployment", "create", "-r", RECIPE_FOLDER_PATH_STR);
         CreateLocalDeploymentRequest request = new CreateLocalDeploymentRequest();
-        request.setRecipeDirectoryPath(deTilde(RECIPE_FOLDER_PATH_STR));
+        request.setRecipeDirectoryPath(deTilde(RECIPE_FOLDER_PATH_STR).get().toString());
         verify(nucleusAdapteripc).createLocalDeployment(request);
         assertThat(exitCode, is(0));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix `AggregationImplTest`. However when doing that, I realized the interface `Aggregation` used `String`, not `Path` to represent path. Therefore I also updated the interface and the code that uses this interface to use `Path`. 

**Why is this change necessary:**
The change is necessary so that the test can run and pass on Windows.

**How was this change tested:**
The test passes on Windows.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
