### PR TITLE
chore(windows): cli version and nucleus dependency in pom.xml

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <licenses>
       <license>

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,10 @@
     <groupId>com.aws.greengrass</groupId>
     <artifactId>cli</artifactId>
     <name>greengrass-cli</name>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <modules>
         <module>server</module>
         <module>client</module>
     </modules>
     <packaging>pom</packaging>
 </project>
-

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <licenses>
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update Cli version to 2.2.0 and also depends on Nucleus 2.2.0.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
