### PR TITLE
fix: do not quit when text logs are encountered

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.2.18</version>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
     <build>
@@ -144,6 +144,18 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:jar:*</artifact>
+                                    <excludes>
+                                        <exclude>*.a</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>software.amazon.awssdk.crt:aws-crt:jar:*</artifact>
+                                    <excludes>
+                                        <exclude>*.a</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/client/src/main/java/com/aws/greengrass/cli/util/logs/LogQueue.java
+++ b/client/src/main/java/com/aws/greengrass/cli/util/logs/LogQueue.java
@@ -13,8 +13,8 @@ import java.util.concurrent.TimeUnit;
  * Bounded blocking queue of LogEntry.
  */
 public class LogQueue {
-    private BlockingQueue<LogEntry> queue;
-    private int capacity;
+    private final BlockingQueue<LogEntry> queue;
+    private final int capacity;
     private Semaphore sem;
 
     public LogQueue(BlockingQueue<LogEntry> queue, int capacity) {

--- a/client/src/main/java/com/aws/greengrass/cli/util/logs/impl/AggregationImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/util/logs/impl/AggregationImpl.java
@@ -95,7 +95,6 @@ public class AggregationImpl implements Aggregation {
         // We initialize the queue here to save overhead for when no log file is provided.
         config.initialize();
 
-
         for (Map.Entry<String, List<LogFile>> entry : logGroupMap.entrySet()) {
             // Here we sort all files in a log group by ascending order of their timestamps and indexes.
             if (!LogsUtil.isSyslog()) {


### PR DESCRIPTION
**Issue #, if available:**
#123 

**Description of changes:**
Resolves #123 by treating text logs as if the whole log line is the message.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
