### PR TITLE
fix: handle the case when runwith flag is null

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -154,9 +154,10 @@ public class DeploymentCommand extends BaseCommand {
 
     private Map<String, RunWithInfo> getComponentToRunWithInfo(Map<String, String> runWithOptions,
             Map<String, SystemResourceLimits> systemLimits) {
-        if (runWithOptions == null || runWithOptions.size() == 0) {
-            return null;
+        if (runWithOptions == null) {
+            runWithOptions = new HashMap<>();
         }
+
         Map<String, RunWithInfo> componentToRunWithInfo = new HashMap<>();
         for (Map.Entry<String, String> entry : runWithOptions.entrySet()) {
             String componentNameAndRunWithOption = entry.getKey();
@@ -187,7 +188,6 @@ public class DeploymentCommand extends BaseCommand {
                 return v;
             });
         }
-
-        return componentToRunWithInfo;
+        return componentToRunWithInfo.isEmpty() ? null : componentToRunWithInfo;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle the case where the runwith is null but the system limits is set
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
