### PR TITLE
feat(windows): support authorized windows groups

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
     <licenses>
       <license>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.aws.greengrass</groupId>
     <artifactId>cli</artifactId>
     <name>greengrass-cli</name>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <modules>
         <module>server</module>
         <module>client</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <licenses>
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.5.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.5.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/server/src/main/java/com/aws/greengrass/cli/CLIService.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIService.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.FileSystemPermission;
+import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
 import com.aws.greengrass.util.platforms.UserPlatform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -227,16 +228,12 @@ public class CLIService extends PluginService {
 
         Topic authorizedGroups = config.find(CONFIGURATION_CONFIG_KEY,
                 Exec.isWindows ? AUTHORIZED_WINDOWS_GROUPS : AUTHORIZED_POSIX_GROUPS);
-        if (authorizedGroups == null) {
+        String groups = Coerce.toString(authorizedGroups);
+        if (Utils.isEmpty(groups)) {
             generateCliIpcInfoForEffectiveUser(authTokenDir);
             return;
         }
 
-        String groups = Coerce.toString(authorizedGroups);
-        if (groups == null || groups.length() == 0) {
-            generateCliIpcInfoForEffectiveUser(authTokenDir);
-            return;
-        }
         for (String group : groups.split(",")) {
             group = group.trim();
             UserPlatform.BasicAttributes groupAttributes;

--- a/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.aws.greengrass.cli.CLIService.AUTHORIZED_WINDOWS_GROUPS;
 import static com.aws.greengrass.cli.CLIService.CLI_AUTH_TOKEN;
 import static com.aws.greengrass.cli.CLIService.CLI_SERVICE;
 import static com.aws.greengrass.cli.CLIService.DOMAIN_SOCKET_PATH;
@@ -112,6 +113,7 @@ class CLIServiceTest extends GGServiceTestUtil {
         verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(eq(Deployment.DeploymentType.LOCAL), any(),
                 eq(CLIService.class.getName()));
         verify(cliConfigSpy).lookup(CONFIGURATION_CONFIG_KEY, AUTHORIZED_POSIX_GROUPS);
+        verify(cliConfigSpy).lookup(CONFIGURATION_CONFIG_KEY, AUTHORIZED_WINDOWS_GROUPS);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Depend on Nucleus 2.5 which has the group lookup implemented
* Remove special case for Windows. 

Note that authorized group still doesn't work on windows even after this PR. We still need to update the named pipe access right. But that would require SDK changes and maybe Nucleus changes. However this PR is still needed. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
