### PR TITLE
refactor: use PlatformResolver.isWindows

### DIFF
--- a/server/src/main/java/com/aws/greengrass/cli/CLIService.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIService.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.cli;
 
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.ImplementsService;
@@ -17,7 +18,6 @@ import com.aws.greengrass.ipc.exceptions.UnauthenticatedException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.FileSystemPermission;
 import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
@@ -227,7 +227,7 @@ public class CLIService extends PluginService {
         revokeOutdatedAuthTokens(authTokenDir);
 
         Topic authorizedGroups = config.find(CONFIGURATION_CONFIG_KEY,
-                Exec.isWindows ? AUTHORIZED_WINDOWS_GROUPS : AUTHORIZED_POSIX_GROUPS);
+                PlatformResolver.isWindows ? AUTHORIZED_WINDOWS_GROUPS : AUTHORIZED_POSIX_GROUPS);
         String groups = Coerce.toString(authorizedGroups);
         if (Utils.isEmpty(groups)) {
             generateCliIpcInfoForEffectiveUser(authTokenDir);

--- a/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.cli;
 
+import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.DeploymentStatusKeeper;
@@ -13,7 +14,6 @@ import com.aws.greengrass.ipc.AuthenticationHandler;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
-import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.platforms.unix.UnixGroupAttributes;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,12 +36,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.aws.greengrass.cli.CLIService.AUTHORIZED_POSIX_GROUPS;
 import static com.aws.greengrass.cli.CLIService.AUTHORIZED_WINDOWS_GROUPS;
 import static com.aws.greengrass.cli.CLIService.CLI_AUTH_TOKEN;
 import static com.aws.greengrass.cli.CLIService.CLI_SERVICE;
 import static com.aws.greengrass.cli.CLIService.DOMAIN_SOCKET_PATH;
 import static com.aws.greengrass.cli.CLIService.OBJECT_MAPPER;
-import static com.aws.greengrass.cli.CLIService.AUTHORIZED_POSIX_GROUPS;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET_FILEPATH;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC;
@@ -144,7 +144,7 @@ class CLIServiceTest extends GGServiceTestUtil {
 
     @Test
     void testStartup_group_auth(ExtensionContext context) throws Exception {
-        if (Exec.isWindows) {
+        if (PlatformResolver.isWindows) {
             // GG_NEEDS_REVIEW: TODO support group auth on Windows
             return;
         }

--- a/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.cli;
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.exceptions.ComponentVersionNegotiationException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeviceConfiguration;
@@ -395,7 +396,7 @@ class IPCCliTest {
         kernel.getContext().addGlobalStateChangeListener(listener);
 
         String validGid;
-        if (Exec.isWindows) {
+        if (PlatformResolver.isWindows) {
             // GG_NEEDS_REVIEW: TODO support windows
             validGid = "0";
         } else {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`Exec.isWindows` -> `PlatformResolver.isWindows`
Because `isWindows` field is duplicated. Removing the one in Exec.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
