### PR TITLE
fix(windows): handle symlinks when finding paths in cmd

### DIFF
--- a/client/src/bin/greengrass-cli.cmd
+++ b/client/src/bin/greengrass-cli.cmd
@@ -1,6 +1,14 @@
 @echo off
+@REM set local scope for variables so we don't leak into the caller's environment
+SETLOCAL
 
 set SCRIPT_PATH=%~dp0
+
+@REM Trace symlink to real path if we were launched from a symlink
+for /f "tokens=2 delims=[]" %%H in  ('dir /al %SCRIPT_PATH* ^| findstr /i /c:"%~nx0"') do (
+    set SCRIPT_PATH=%%~dpH
+)
+
 set CLI_HOME=%SCRIPT_PATH%..
 If Not Defined GGC_ROOT_PATH (
     set GGC_ROOT_PATH=%CLI_HOME%\..\..\..\..\..\..


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Necessary since customers access CLI via <ggroot>/bin/greengrass-cli.cmd which symlinks to the real path. The script itself needs to know the real path so that it can properly find the java jar path.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
