### PR TITLE
fix: setting both runWith posixUser and windowsUser

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -9,7 +9,6 @@ import com.aws.greengrass.cli.adapter.NucleusAdapterIpc;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import picocli.CommandLine;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
@@ -20,7 +19,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,11 +162,12 @@ public class DeploymentCommand extends BaseCommand {
             String componentNameAndRunWithOption = entry.getKey();
             String[] parts = componentNameAndRunWithOption.split(":");
             if (parts.length != 2) {
-                throw new IllegalArgumentException("--runWith must be in the following format <component>:posixUser=<user>[:<group>] ");
+                throw new IllegalArgumentException("--runWith must be in the following format "
+                        + "<component>:{posixUser|windowsUser}=<user>[:<group>] ");
             }
             String componentName = parts[0];
             String runWithOption = parts[1];
-            RunWithInfo runWithInfo = new RunWithInfo();
+            RunWithInfo runWithInfo = componentToRunWithInfo.computeIfAbsent(componentName, k -> new RunWithInfo());
             switch (runWithOption) {
                 case RUN_WITH_OPTION_POSIX_USER:
                     runWithInfo.setPosixUser(entry.getValue());
@@ -179,7 +178,6 @@ public class DeploymentCommand extends BaseCommand {
                 default:
                     throw new IllegalArgumentException("Invalid --runWith option: " + runWithOption);
             }
-            componentToRunWithInfo.put(componentName, runWithInfo);
         }
 
         for (Map.Entry<String, SystemResourceLimits> mapEntry : systemLimits.entrySet()) {

--- a/client/src/main/resources/com/aws/greengrass/cli/CLI_messages.properties
+++ b/client/src/main/resources/com/aws/greengrass/cli/CLI_messages.properties
@@ -22,7 +22,7 @@ greengrass-cli.deployment.create.recipeDir=The path to the directory that contai
 greengrass-cli.deployment.create.artifactDir=The path to the directory that contains your artifact files.%n\
   The artifact directory must contain the following structure: /<component-name>/<version>/<artifacts>.
 greengrass-cli.deployment.create.runWith=The user and/or group used to run the component.%n\
-  Format: <component>:posixUser=<user>[:<group>]. Example: HelloWorld:posixUser=ggc_user, HelloWorld:posixUser=ggc_user:ggc_group.%n\
+  Format: <component>:{posixUser|windowsUser}=<user>[:<group>]. Example: HelloWorld:windowsUser=ggc_user, HelloWorld:posixUser=ggc_user:ggc_group.%n\
   Use a separate argument for each additional option to specify.
 greengrass-cli.deployment.create.groupId=The thing group that the deployment targets.
 greengrass-cli.deployment.create.update-config=The configuration update JSON string or JSON file. Use the following JSON format:%n\

--- a/client/src/test/java/com/aws/greengrass/cli/commands/DeploymentCommandTest.java
+++ b/client/src/test/java/com/aws/greengrass/cli/commands/DeploymentCommandTest.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.RunWithInfo;
 import software.amazon.awssdk.aws.greengrass.model.SystemResourceLimits;
 
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -146,13 +145,14 @@ class DeploymentCommandTest {
 
     @Test
     void GIVEN_WHEN_components_runwith_provided_THEN_request_contains_the_info() throws Exception {
-        int exitCode = runCommandLine("deployment", "create", "--runWith" , "Component1:windowsUser=foo:bar",
-                "--runWith" , "Component2:posixUser=1234", "--systemLimits",
+        int exitCode = runCommandLine("deployment", "create",
+                "--runWith", "Component1:windowsUser=foobar", "--runWith", "Component2:windowsUser=foobar",
+                "--runWith", "Component2:posixUser=1234", "--systemLimits",
                 Paths.get(this.getClass().getResource("resource_limits.json").toURI()).toString());
 
         Map<String, RunWithInfo> componentToRunWithInfo = new HashMap<>();
         RunWithInfo runWithInfo = new RunWithInfo();
-        runWithInfo.setWindowsUser("foo:bar");
+        runWithInfo.setWindowsUser("foobar");
 
         MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class,
                 SystemResourceLimits.class);
@@ -164,6 +164,7 @@ class DeploymentCommandTest {
 
         runWithInfo = new RunWithInfo();
         runWithInfo.setPosixUser("1234");
+        runWithInfo.setWindowsUser("foobar");
         componentToRunWithInfo.put("Component2", runWithInfo);
 
         CreateLocalDeploymentRequest request = new CreateLocalDeploymentRequest();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Allow setting both --runWith windowsUser and posixUser for the same component
- Update usage example

**Why is this change necessary:**
It is valid to set both.

**How was this change tested:**
CI

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
