### PR TITLE
feat: add authZ lookup to allow non-CLI clients to call the APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Build with Maven (not Windows)
         run: mvn -U -ntp clean verify
         if: matrix.os != 'windows-latest'
+      - name: Upload Failed Test Report
+        uses: actions/upload-artifact@v1.0.0
+        if: failure()
+        with:
+          name: Failed Test Report ${{ matrix.os }}
+          path: server/target/surefire-reports
       - name: Convert Jacoco to Cobertura
         run: |
           python3 ./.github/scripts/cover2cover.py client/target/jacoco-report/jacoco.xml src/main/java > client/target/jacoco-report/cobertura.xml

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.5.1-WINDOWS-SNAPSHOT</version>
+            <version>1.9.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
@@ -108,6 +108,8 @@ class IPCCliTest extends BaseITCase {
 
     @BeforeAll
     static void beforeAll() throws Exception {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = prepareKernelFromConfigFile("ipc.yaml", IPCCliTest.class, CLI_SERVICE, TEST_SERVICE_NAME);
         BaseITCase.setDeviceConfig(kernel, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
         eventStreamRpcConnection = getEventStreamRpcConnection(kernel, CLI_SERVICE);

--- a/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/IPCCliTest.java
@@ -14,10 +14,12 @@ import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.platforms.Platform;
@@ -25,6 +27,7 @@ import com.aws.greengrass.util.platforms.unix.UnixPlatform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -75,7 +78,6 @@ import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURA
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.TEST_SERVICE_NAME;
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.getEventStreamRpcConnection;
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.getListenerForServiceRunning;
-import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.prepareKernelFromConfigFile;
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.waitForDeploymentToBeSuccessful;
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.waitForServiceToComeInState;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUN_WITH_NAMESPACE_TOPIC;
@@ -114,6 +116,19 @@ class IPCCliTest extends BaseITCase {
         BaseITCase.setDeviceConfig(kernel, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
         eventStreamRpcConnection = getEventStreamRpcConnection(kernel, CLI_SERVICE);
         clientConnection = new GreengrassCoreIPCClient(eventStreamRpcConnection);
+    }
+
+    public static Kernel prepareKernelFromConfigFile(String configFile, Class testClass, String... serviceNames) throws InterruptedException, IOException {
+        Kernel kernel = new Kernel();
+        NoOpPathOwnershipHandler.register(kernel);
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel, testClass.getResource(configFile));
+        CountDownLatch awaitIpcServiceLatch = new CountDownLatch(serviceNames.length);
+        GlobalStateChangeListener listener = getListenerForServiceRunning(awaitIpcServiceLatch, serviceNames);
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        Assertions.assertTrue(awaitIpcServiceLatch.await(60L, TimeUnit.SECONDS));
+        kernel.getContext().removeGlobalStateChangeListener(listener);
+        return kernel;
     }
 
     @AfterAll


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds authZ lookups using our standard `AuthorizationHandler`, thus enabling customer components to call CLI-based APIs in their own components after adding the necessary authorization policy. The CLI and CLI clients still short-circuit this logic and are allowed to perform any operation as before.

In the authorization policy, the resource is most often the component name which we're acting on. In other cases we use `*` since no more specific resource makes sense (ie. when listing components or deployments).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
