### PR TITLE
fix: use illegal component name character in generated tokens

### DIFF
--- a/server/src/main/java/com/aws/greengrass/cli/CLIService.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIService.java
@@ -48,7 +48,7 @@ import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET
 
 @ImplementsService(name = CLIService.CLI_SERVICE, autostart = true)
 public class CLIService extends PluginService {
-    public static final String GREENGRASS_CLI_CLIENT_ID_PREFIX = "greengrass-cli-";
+    public static final String GREENGRASS_CLI_CLIENT_ID_PREFIX = "greengrass-cli#";
     public static final String GREENGRASS_CLI_CLIENT_ID_FMT = GREENGRASS_CLI_CLIENT_ID_PREFIX + "%s";
     public static final String CLI_SERVICE = "aws.greengrass.Cli";
     public static final String CLI_CLIENT_ARTIFACT = "aws.greengrass.cli.client";

--- a/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIServiceTest.java
@@ -130,7 +130,7 @@ class CLIServiceTest extends GGServiceTestUtil {
         cliService.startup();
         verifyHandlersRegisteredForAllOperations();
         verify(authenticationHandler).registerAuthenticationTokenForExternalClient
-                (anyString(), startsWith("greengrass-cli-user"));
+                (anyString(), startsWith("greengrass-cli#user"));
 
         Path authDir = nucleusPaths.cliIpcInfoPath();
         assertTrue(Files.exists(authDir));
@@ -154,9 +154,9 @@ class CLIServiceTest extends GGServiceTestUtil {
         when(authenticationHandler.registerAuthenticationTokenForExternalClient(anyString(), anyString()))
                 .thenAnswer(i -> {
                     Object clientId = i.getArgument(1);
-                    if ("greengrass-cli-group-123".equals(clientId)) {
+                    if ("greengrass-cli#group-123".equals(clientId)) {
                         return MOCK_AUTH_TOKEN;
-                    } else if ("greengrass-cli-group-456".equals(clientId)) {
+                    } else if ("greengrass-cli#group-456".equals(clientId)) {
                         return MOCK_AUTH_TOKEN_2;
                     }
                     throw new InvalidUseOfMatchersException(
@@ -197,8 +197,8 @@ class CLIServiceTest extends GGServiceTestUtil {
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(authenticationHandler, times(2)).registerAuthenticationTokenForExternalClient
                 (anyString(), argument.capture());
-        assertThat(argument.getAllValues(), containsInRelativeOrder("greengrass-cli-group-123",
-                "greengrass-cli-group-456"));
+        assertThat(argument.getAllValues(), containsInRelativeOrder("greengrass-cli#group-123",
+                "greengrass-cli#group-456"));
 
         Path authDir = nucleusPaths.cliIpcInfoPath();
         assertTrue(Files.exists(authDir.resolve("group-123")));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Following up on https://github.com/aws-greengrass/aws-greengrass-cli/pull/157#discussion_r886178018. Using `#` in the name of the client we generate since `#` isn't allowed in customer component names.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
