### PR TITLE
test: include test for component calling CLI IPC API

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/server/src/test/resources/com/aws/greengrass/cli/ipc.yaml
+++ b/server/src/test/resources/com/aws/greengrass/cli/ipc.yaml
@@ -20,6 +20,16 @@ services:
     lifecycle: {}
     version: 1.0.0
   ServiceName:
+    configuration:
+      accessControl:
+        aws.greengrass.Cli:
+          testPolicy1:
+            policyDescription: "Test policy"
+            operations:
+              - aws.greengrass#GetComponentDetails
+              - aws.greengrass#ListComponents
+            resources:
+              - '*'
     lifecycle:
       run:
         windows:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Requires https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1229. Adds a test to validate the functionality of a component calling CLI implemented APIs.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
