### PR TITLE
fix: pubsub receive all messages, logging improvement

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
@@ -68,6 +68,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -498,6 +500,8 @@ public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
                 socketOptions, null, ipcServerSocketPath, 8033,
                 GreengrassConnectMessageSupplier.connectMessageSupplier(authToken));
         final CompletableFuture<Void> connected = new CompletableFuture<>();
+        // Disable silly info logs (ERROR_SUCCESS) which aren't helpful to us. Important messages will still be logged.
+        Logger.getLogger(EventStreamRPCConnection.class.getName()).setLevel(Level.WARNING);
         final EventStreamRPCConnection connection = new EventStreamRPCConnection(config);
 
         connection.connect(new EventStreamRPCConnection.LifecycleHandler() {

--- a/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.PublishToTopicRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToTopicResponse;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
+import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
 import software.amazon.awssdk.aws.greengrass.model.RestartComponentRequest;
 import software.amazon.awssdk.aws.greengrass.model.StopComponentRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
@@ -52,9 +53,6 @@ import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnectionConfig;
 import software.amazon.awssdk.eventstreamrpc.GreengrassConnectMessageSupplier;
 import software.amazon.awssdk.eventstreamrpc.StreamResponseHandler;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -70,6 +68,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
 
@@ -401,6 +402,7 @@ public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
             , String topic, StreamResponseHandler<SubscriptionResponseMessage> streamResponseHandler) {
         SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
         subscribeToTopicRequest.setTopic(topic);
+        subscribeToTopicRequest.setReceiveMode(ReceiveMode.RECEIVE_ALL_MESSAGES);
         return greengrassCoreIPCClient.subscribeToTopic(subscribeToTopicRequest,
                 Optional.of(streamResponseHandler));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- When subscribing, set the option to receive all messages so that publishing from the CLI will result in the CLI's subscriber (if any) also receiving the message.
- fixes CLI so that it shuts down after it has subscribed and the stream closes for any reason, such as the Nucleus restarting.
- raise log level for EventStreamRPCConnection to only log warning+.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
