### PR TITLE
feat: tune status and list command to be consistent with cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,9 @@ To send us a pull request, please:
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+#### Note
+The Server module imports the [aws.greengrass.Nucleus](https://github.com/aws-greengrass/aws-greengrass-nucleus) as a maven dependency so it is recommended to update
+dependency versions in the Nucleus repository (if exists) before adding dependencies to the Server module.
 
 
 ## Finding contributions to work on

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.1-CLI-SNAPSHOT</version>
+            <version>1.12.2-CLI-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/client/src/main/java/com/aws/greengrass/cli/adapter/NucleusAdapterIpc.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/NucleusAdapterIpc.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.aws.greengrass.model.ComponentDetails;
 import software.amazon.awssdk.aws.greengrass.model.CreateDebugPasswordResponse;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +25,7 @@ public interface NucleusAdapterIpc {
 
     void stopComponent(String... componentNames);
 
-    LocalDeployment getLocalDeploymentStatus(String deploymentId);
+    LocalDeploymentStatus getLocalDeploymentStatus(String deploymentId);
 
     List<LocalDeployment> listLocalDeployments();
 

--- a/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.aws.greengrass.model.ListComponentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsRequest;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 import software.amazon.awssdk.aws.greengrass.model.PublishMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
@@ -156,13 +157,13 @@ public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
     }
 
     @Override
-    public LocalDeployment getLocalDeploymentStatus(String deploymentId) {
+    public LocalDeploymentStatus getLocalDeploymentStatus(String deploymentId) {
 
         try {
             GetLocalDeploymentStatusRequest request = new GetLocalDeploymentStatusRequest();
             request.setDeploymentId(deploymentId);
             GetLocalDeploymentStatusResponseHandler localDeploymentStatus = getIpcClient().getLocalDeploymentStatus(request, Optional.empty());
-            LocalDeployment deployment = localDeploymentStatus.getResponse()
+            LocalDeploymentStatus deployment = localDeploymentStatus.getResponse()
                     .get(DEFAULT_TIMEOUT_IN_SEC, TimeUnit.SECONDS).getDeployment();
             return deployment;
         } catch (ExecutionException | TimeoutException | InterruptedException e) {

--- a/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -12,8 +12,10 @@ import com.fasterxml.jackson.databind.type.MapType;
 import picocli.CommandLine;
 import software.amazon.awssdk.aws.greengrass.model.CancelLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
+import software.amazon.awssdk.aws.greengrass.model.DeploymentStatusDetails;
 import software.amazon.awssdk.aws.greengrass.model.FailureHandlingPolicy;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 import software.amazon.awssdk.aws.greengrass.model.RunWithInfo;
 import software.amazon.awssdk.aws.greengrass.model.SystemResourceLimits;
 
@@ -21,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -151,23 +154,79 @@ public class DeploymentCommand extends BaseCommand {
     }
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
+    /*
+    Output example:
+    Deployment ID: Deployment UUID
+    Created on: Time in UTC when the deployment was created (dd-MM-uuuu HH:mm:ss UTC)
+    Status: DEPLOYMENT_STATUS
+    Deployment Error Stack: [List, of, deployment, error, if, any] (null if successful deployment)
+    Deployment Error Types: [List, of, deployment, error, types, if, any] (null if successful deployment)
+    Deployment Failure Cause: Deployment failure cause in text (null if successful deployment)
+     */
     @CommandLine.Command(name = "status",
             description = "Retrieve the status of a specific deployment", mixinStandardHelpOptions = true,
             versionProvider = com.aws.greengrass.cli.module.VersionProvider.class)
     public int status(@CommandLine.Option(names = {"-i", "--deploymentId"}, paramLabel = "Deployment ID",
             required = true) String deploymentId) {
 
-        LocalDeployment status = nucleusAdapterIpc.getLocalDeploymentStatus(deploymentId);
-        System.out.printf("%s: %s%n", status.getDeploymentId(), status.getStatus());
+        LocalDeploymentStatus status = nucleusAdapterIpc.getLocalDeploymentStatus(deploymentId);
+        StringBuilder statusBuilder = new StringBuilder();
+        statusBuilder.append(String.format(
+                "Deployment ID: %s\n", status.getDeploymentId()));
+        statusBuilder.append(String.format(
+                "Created on: %s\n", status.getCreatedOn()));
+        String deploymentStatus = String.valueOf(status.getStatus());
+        DeploymentStatusDetails deploymentStatusDetails = status.getDeploymentStatusDetails();
+        if (deploymentStatusDetails != null) {
+            deploymentStatus = deploymentStatusDetails.getDetailedDeploymentStatusAsString();
+            statusBuilder.append(String.format("Status: %s\n", deploymentStatus));
+            if (deploymentStatusDetails.getDeploymentErrorStack() != null &&
+                    !deploymentStatusDetails.getDeploymentErrorStack().isEmpty()) {
+                statusBuilder.append(String.format("Deployment Error Stack: %s\n",
+                        String.join(", ", deploymentStatusDetails.getDeploymentErrorStack())));
+            }
+            if (deploymentStatusDetails.getDeploymentErrorTypes() != null &&
+                    !deploymentStatusDetails.getDeploymentErrorTypes().isEmpty()) {
+                statusBuilder.append(String.format("Deployment Error Types: %s\n",
+                        String.join(", ", deploymentStatusDetails.getDeploymentErrorTypes())));
+            }
+            if (deploymentStatusDetails.getDeploymentFailureCause() != null &&
+                    !deploymentStatusDetails.getDeploymentFailureCause().trim().isEmpty()) {
+                statusBuilder.append(String.format(
+                        "Deployment Failure Cause: %s\n", deploymentStatusDetails.getDeploymentFailureCause()));
+            }
+        } else {
+            statusBuilder.append(String.format("Status: %s\n", deploymentStatus));
+        }
+        System.out.printf(statusBuilder.toString());
         return 0;
     }
 
     // GG_NEEDS_REVIEW: TODO: input validation and better error handling https://sim.amazon.com/issues/P39478724
+    /*
+    Output example:
+    Deployment ID: Deployment UUID 1
+    Created on: Time in UTC when the deployment was created (dd-MM-uuuu HH:mm:ss UTC)
+    Status: DEPLOYMENT_STATUS_1
+
+    Deployment ID: Deployment UUID 2
+    Created on: Time in UTC when the deployment was created (dd-MM-uuuu HH:mm:ss UTC)
+    Status: DEPLOYMENT_STATUS_2
+
+    ...
+     */
     @CommandLine.Command(name = "list", description = "Retrieve the status of local deployments",
             mixinStandardHelpOptions = true, versionProvider = com.aws.greengrass.cli.module.VersionProvider.class)
     public int list() {
         List<LocalDeployment> localDeployments = nucleusAdapterIpc.listLocalDeployments();
-        localDeployments.forEach((status) -> System.out.println(status.getDeploymentId() + ": " + status.getStatus()));
+        List<String> localDeploymentShortStatuses = new ArrayList<>();
+        for (LocalDeployment localDeployment : localDeployments) {
+            String statusBuilder = String.format("Deployment ID: %s\n", localDeployment.getDeploymentId()) +
+                    String.format("Created on: %s\n", localDeployment.getCreatedOn()) +
+                    String.format("Status: %s\n", localDeployment.getStatus());
+            localDeploymentShortStatuses.add(statusBuilder);
+        }
+        System.out.printf(String.join("\n", localDeploymentShortStatuses));
         return 0;
     }
 

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -48,6 +48,8 @@ import software.amazon.awssdk.aws.greengrass.model.CreateDebugPasswordResponse;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentResponse;
 import software.amazon.awssdk.aws.greengrass.model.DeploymentStatus;
+import software.amazon.awssdk.aws.greengrass.model.DeploymentStatusDetails;
+import software.amazon.awssdk.aws.greengrass.model.DetailedDeploymentStatus;
 import software.amazon.awssdk.aws.greengrass.model.GetComponentDetailsRequest;
 import software.amazon.awssdk.aws.greengrass.model.GetComponentDetailsResponse;
 import software.amazon.awssdk.aws.greengrass.model.GetLocalDeploymentStatusRequest;
@@ -60,6 +62,7 @@ import software.amazon.awssdk.aws.greengrass.model.ListComponentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsRequest;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 import software.amazon.awssdk.aws.greengrass.model.RequestStatus;
 import software.amazon.awssdk.aws.greengrass.model.ResourceNotFoundError;
 import software.amazon.awssdk.aws.greengrass.model.RestartComponentRequest;
@@ -76,11 +79,15 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +100,12 @@ import static com.aws.greengrass.cli.CLIService.GREENGRASS_CLI_CLIENT_ID_PREFIX;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_STACK_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
@@ -112,8 +124,11 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCServiceMode
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class CLIEventStreamAgent {
     public static final String PERSISTENT_LOCAL_DEPLOYMENTS = "LocalDeployments";
+    public static final String DEPLOYMENT_STATUS_DETAILS_KEY_NAME = "DeploymentStatusDetails";
+    public static final String DETAILED_DEPLOYMENT_STATUS_KEY =  "detailed-deployment-status";
     public static final String LOCAL_DEPLOYMENT_RESOURCE = "LocalDeployment";
-
+    public static final String LOCAL_DEPLOYMENT_CREATED_ON = "CreatedOn";
+    public static final String LOCAL_DEPLOYMENT_CREATED_ON_FORMATTER = "dd-MM-uuuu HH:mm:ss z";
     private static final Logger logger = LogManager.getLogger(CLIEventStreamAgent.class);
     private static final ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
@@ -187,6 +202,10 @@ public class CLIEventStreamAgent {
         Topics localDeployments = serviceConfig.lookupTopics(PERSISTENT_LOCAL_DEPLOYMENTS);
         String deploymentId = (String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME);
         Topics localDeploymentDetails = localDeployments.lookupTopics(deploymentId);
+        if (localDeploymentDetails.find(LOCAL_DEPLOYMENT_CREATED_ON) != null) {
+            deploymentDetails.put(LOCAL_DEPLOYMENT_CREATED_ON,
+                    Coerce.toLong(localDeploymentDetails.find(LOCAL_DEPLOYMENT_CREATED_ON)));
+        }
         localDeploymentDetails.replaceAndWait(deploymentDetails);
         // TODO: [P41178971]: Implement a limit on no of local deployments to persist status for
     }
@@ -503,6 +522,7 @@ public class CLIEventStreamAgent {
                     localDeploymentDetails.setDeploymentId(deploymentId);
                     localDeploymentDetails.setDeploymentType(Deployment.DeploymentType.LOCAL);
                     localDeploymentDetails.setStatus(DeploymentStatus.QUEUED);
+                    localDeploymentDetails.setCreatedOn(System.currentTimeMillis());
                     cleanUpQueuedDeployments(cliServiceConfig);
 
                     persistLocalDeployment(cliServiceConfig, localDeploymentDetails.convertToMapOfObject());
@@ -657,13 +677,40 @@ public class CLIEventStreamAgent {
                     throw rnf;
                 } else {
                     Topics deployment = localDeployments.findTopics(request.getDeploymentId());
+                    LocalDeploymentStatus localDeploymentStatus = new LocalDeploymentStatus();
+                    localDeploymentStatus.setDeploymentId(request.getDeploymentId());
+                    localDeploymentStatus.setCreatedOn(Instant.ofEpochMilli(
+                            Coerce.toLong(deployment.find(LOCAL_DEPLOYMENT_CREATED_ON)))
+                            .atZone(ZoneId.of("UTC"))
+                            .format(DateTimeFormatter.ofPattern(LOCAL_DEPLOYMENT_CREATED_ON_FORMATTER)));
                     DeploymentStatus status =
                             deploymentStatusFromString(Coerce.toString(deployment.find(DEPLOYMENT_STATUS_KEY_NAME)));
+                    localDeploymentStatus.setStatus(status);
+                    if (deployment.findTopics(DEPLOYMENT_STATUS_DETAILS_KEY_NAME) != null) {
+                        Topics deploymentStatusDetailsTopics =
+                                deployment.findTopics(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
+                        DeploymentStatusDetails deploymentStatusDetails = new DeploymentStatusDetails();
+                        DetailedDeploymentStatus detailedDeploymentStatus = detailedDeploymentStatusFromString(
+                                Coerce.toString(deploymentStatusDetailsTopics.find(DETAILED_DEPLOYMENT_STATUS_KEY)));
+                        deploymentStatusDetails.setDetailedDeploymentStatus(detailedDeploymentStatus);
+                        if (deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_STACK_KEY) != null) {
+                            deploymentStatusDetails.setDeploymentErrorStack(
+                                    (List<String>) deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_STACK_KEY)
+                                            .getOnce());
+                        }
+                        if (deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_TYPES_KEY) != null) {
+                            deploymentStatusDetails.setDeploymentErrorTypes(
+                                    (List<String>) deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_TYPES_KEY)
+                                            .getOnce());
+                        }
+                        if (deploymentStatusDetailsTopics.find(DEPLOYMENT_FAILURE_CAUSE_KEY) != null) {
+                            deploymentStatusDetails.setDeploymentFailureCause(
+                                    Coerce.toString(deploymentStatusDetailsTopics.find(DEPLOYMENT_FAILURE_CAUSE_KEY)));
+                        }
+                        localDeploymentStatus.setDeploymentStatusDetails(deploymentStatusDetails);
+                    }
                     GetLocalDeploymentStatusResponse response = new GetLocalDeploymentStatusResponse();
-                    LocalDeployment localDeployment = new LocalDeployment();
-                    localDeployment.setDeploymentId(request.getDeploymentId());
-                    localDeployment.setStatus(status);
-                    response.setDeployment(localDeployment);
+                    response.setDeployment(localDeploymentStatus);
                     return response;
                 }
             });
@@ -703,6 +750,7 @@ public class CLIEventStreamAgent {
         @Override
         public ListLocalDeploymentsResponse handleRequest(ListLocalDeploymentsRequest request) {
             return translateExceptions(() -> {
+                logger.atDebug().log("Listing persisted local deployments");
                 authorizeRequest(Permission.builder()
                         .principal(componentName)
                         .resource(AuthorizationHandler.ANY_REGEX)
@@ -718,6 +766,10 @@ public class CLIEventStreamAgent {
                         localDeployment.setDeploymentId(topics.getName());
                         localDeployment.setStatus(
                                 deploymentStatusFromString(Coerce.toString(topics.find(DEPLOYMENT_STATUS_KEY_NAME))));
+                        localDeployment.setCreatedOn(Instant.ofEpochMilli(
+                                        Coerce.toLong(topics.find(LOCAL_DEPLOYMENT_CREATED_ON)))
+                                .atZone(ZoneId.of("UTC"))
+                                .format(DateTimeFormatter.ofPattern(LOCAL_DEPLOYMENT_CREATED_ON_FORMATTER)));
                         persistedDeployments.add(localDeployment);
                     });
                 }
@@ -795,6 +847,15 @@ public class CLIEventStreamAgent {
         }
     }
 
+    private DetailedDeploymentStatus detailedDeploymentStatusFromString(String detailedDeploymentStatus) {
+        for (DetailedDeploymentStatus ds : DetailedDeploymentStatus.values()) {
+            if (ds.getValue().equals(detailedDeploymentStatus.toUpperCase())) {
+                return ds;
+            }
+        }
+        return null;
+    }
+
     private DeploymentStatus deploymentStatusFromString(String status) {
         for (DeploymentStatus ds : DeploymentStatus.values()) {
             if (ds.getValue().equals(status.toUpperCase())) {
@@ -849,6 +910,8 @@ public class CLIEventStreamAgent {
         private DeploymentStatus status;
         @JsonProperty(DEPLOYMENT_TYPE_KEY_NAME)
         private Deployment.DeploymentType deploymentType;
+        @JsonProperty(LOCAL_DEPLOYMENT_CREATED_ON)
+        private long createdOn;
 
         /**
          * Returns a map of string to object representing the deployment details.
@@ -860,6 +923,7 @@ public class CLIEventStreamAgent {
             deploymentDetails.put(DEPLOYMENT_ID_KEY_NAME, deploymentId);
             deploymentDetails.put(DEPLOYMENT_STATUS_KEY_NAME, status.getValue());
             deploymentDetails.put(DEPLOYMENT_TYPE_KEY_NAME, Coerce.toString(deploymentType));
+            deploymentDetails.put(LOCAL_DEPLOYMENT_CREATED_ON, createdOn);
             return deploymentDetails;
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cli deployment list and status commands now have production ready information like detailed deployment status, error codes, etc. which makes the output more consistent with cloud.

**Why is this change necessary:**
Till now, Cli deployment command response was minimal and not consistent with cloud (not ready for prod)

**How was this change tested:**
Change was tested with manual verification and unit tests. Also manually verified Nucleus and Cli upgrade downgrade scenario.
1. Started with Nucleus and Cli 2.8.1 and verified Cli command outputs
2. Upgraded Nucleus and Cli to latest (with proposed changes) and verified Cli command outputs
3. Downgraded Nucleus and Cli back to 2.8.1 and verified Cli command outputs

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
