### PR TITLE
feat: tune status and list command + incompatibility fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,9 @@ To send us a pull request, please:
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+#### Note
+The Server module imports the [aws.greengrass.Nucleus](https://github.com/aws-greengrass/aws-greengrass-nucleus) as a maven dependency so it is recommended to update
+dependency versions in the Nucleus repository (if exists) before adding dependencies to the Server module.
 
 
 ## Finding contributions to work on

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.1-CLI-SNAPSHOT</version>
+            <version>1.12.2-CLI-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/client/src/main/java/com/aws/greengrass/cli/adapter/NucleusAdapterIpc.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/NucleusAdapterIpc.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.aws.greengrass.model.ComponentDetails;
 import software.amazon.awssdk.aws.greengrass.model.CreateDebugPasswordResponse;
 import software.amazon.awssdk.aws.greengrass.model.CreateLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +25,7 @@ public interface NucleusAdapterIpc {
 
     void stopComponent(String... componentNames);
 
-    LocalDeployment getLocalDeploymentStatus(String deploymentId);
+    LocalDeploymentStatus getLocalDeploymentStatus(String deploymentId);
 
     List<LocalDeployment> listLocalDeployments();
 

--- a/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
+++ b/client/src/main/java/com/aws/greengrass/cli/adapter/impl/NucleusAdapterIpcClientImpl.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.aws.greengrass.model.ListComponentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsRequest;
 import software.amazon.awssdk.aws.greengrass.model.ListLocalDeploymentsResponse;
 import software.amazon.awssdk.aws.greengrass.model.LocalDeployment;
+import software.amazon.awssdk.aws.greengrass.model.LocalDeploymentStatus;
 import software.amazon.awssdk.aws.greengrass.model.PublishMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
@@ -156,13 +157,13 @@ public class NucleusAdapterIpcClientImpl implements NucleusAdapterIpc {
     }
 
     @Override
-    public LocalDeployment getLocalDeploymentStatus(String deploymentId) {
+    public LocalDeploymentStatus getLocalDeploymentStatus(String deploymentId) {
 
         try {
             GetLocalDeploymentStatusRequest request = new GetLocalDeploymentStatusRequest();
             request.setDeploymentId(deploymentId);
             GetLocalDeploymentStatusResponseHandler localDeploymentStatus = getIpcClient().getLocalDeploymentStatus(request, Optional.empty());
-            LocalDeployment deployment = localDeploymentStatus.getResponse()
+            LocalDeploymentStatus deployment = localDeploymentStatus.getResponse()
                     .get(DEFAULT_TIMEOUT_IN_SEC, TimeUnit.SECONDS).getDeployment();
             return deployment;
         } catch (ExecutionException | TimeoutException | InterruptedException e) {

--- a/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
+++ b/server/src/test/java/com/aws/greengrass/cli/CLIEventStreamAgentTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentQueue;
 import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.deployment.model.LocalOverrideRequest;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -60,16 +61,28 @@ import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.aws.greengrass.cli.CLIEventStreamAgent.LOCAL_DEPLOYMENT_CREATED_ON;
+import static com.aws.greengrass.cli.CLIEventStreamAgent.LOCAL_DEPLOYMENT_CREATED_ON_FORMATTER;
 import static com.aws.greengrass.cli.CLIEventStreamAgent.PERSISTENT_LOCAL_DEPLOYMENTS;
 import static com.aws.greengrass.cli.CLIService.CLI_SERVICE;
 import static com.aws.greengrass.cli.CLIService.GREENGRASS_CLI_CLIENT_ID_FMT;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_STACK_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.ipc.common.IPCErrorStrings.DEPLOYMENTS_QUEUE_NOT_INITIALIZED;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
@@ -489,8 +502,70 @@ class CLIEventStreamAgentTest {
     }
 
     @Test
+    void testGetLocalDeploymentStatus_deployment_completes_succeeded() throws IOException {
+        Topics localDeployments = mock(Topics.class);
+        Topics mockCliConfig = mock(Topics.class);
+        try (Context context = new Context()) {
+            String deploymentId = UUID.randomUUID().toString();
+            Topics mockLocalDeployment = Topics.of(context, deploymentId, null);
+            long creationTime = System.currentTimeMillis();
+            mockLocalDeployment.lookup(LOCAL_DEPLOYMENT_CREATED_ON).withValue(creationTime);
+            mockLocalDeployment.lookup(DEPLOYMENT_STATUS_KEY_NAME).withValue(DeploymentStatus.SUCCEEDED.toString());
+            Topics mockLocalDeploymentStatusDetails = mockLocalDeployment.createInteriorChild(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
+            mockLocalDeploymentStatusDetails.lookup(DEPLOYMENT_DETAILED_STATUS_KEY).withValue(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString());
+            when(mockCliConfig.findTopics(PERSISTENT_LOCAL_DEPLOYMENTS)).thenReturn(localDeployments);
+            when(localDeployments.findTopics(deploymentId)).thenReturn(mockLocalDeployment);
+            GetLocalDeploymentStatusRequest request = new GetLocalDeploymentStatusRequest();
+            request.setDeploymentId(deploymentId);
+            GetLocalDeploymentStatusResponse response =
+                    cliEventStreamAgent.getGetLocalDeploymentStatusHandler(mockContext, mockCliConfig)
+                            .handleRequest(request);
+            assertEquals(deploymentId, response.getDeployment().getDeploymentId());
+            assertEquals(Instant.ofEpochMilli(creationTime).atZone(ZoneId.of("UTC"))
+                    .format(DateTimeFormatter.ofPattern(LOCAL_DEPLOYMENT_CREATED_ON_FORMATTER)), response.getDeployment().getCreatedOn());
+            assertEquals(DeploymentStatus.SUCCEEDED, response.getDeployment().getStatus());
+            assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString(),
+                    response.getDeployment().getDeploymentStatusDetails().getDetailedDeploymentStatus().toString());
+        }
+    }
+
+    @Test
+    void testGetLocalDeploymentStatus_deployment_completes_failed() throws IOException {
+        Topics localDeployments = mock(Topics.class);
+        Topics mockCliConfig = mock(Topics.class);
+        try (Context context = new Context()) {
+            String deploymentId = UUID.randomUUID().toString();
+            Topics mockLocalDeployment = Topics.of(context, deploymentId, null);
+            mockLocalDeployment.lookup(DEPLOYMENT_STATUS_KEY_NAME).withValue(DeploymentStatus.FAILED.toString());
+            Topics mockLocalDeploymentStatusDetails = mockLocalDeployment.createInteriorChild(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
+            mockLocalDeploymentStatusDetails.lookup(DEPLOYMENT_DETAILED_STATUS_KEY).withValue(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE.toString());
+            mockLocalDeploymentStatusDetails.lookup(DEPLOYMENT_ERROR_STACK_KEY).withValue(Arrays.asList("ERROR_STACK_1", "ERROR_STACK_2", "ERROR_STACK_3"));
+            mockLocalDeploymentStatusDetails.lookup(DEPLOYMENT_ERROR_TYPES_KEY).withValue(Collections.singletonList("ERROR_TYPE_1"));
+            mockLocalDeploymentStatusDetails.lookup(DEPLOYMENT_FAILURE_CAUSE_KEY).withValue("FAILURE_CAUSE");
+            when(mockCliConfig.findTopics(PERSISTENT_LOCAL_DEPLOYMENTS)).thenReturn(localDeployments);
+            when(localDeployments.findTopics(deploymentId)).thenReturn(mockLocalDeployment);
+            GetLocalDeploymentStatusRequest request = new GetLocalDeploymentStatusRequest();
+            request.setDeploymentId(deploymentId);
+            GetLocalDeploymentStatusResponse response =
+                    cliEventStreamAgent.getGetLocalDeploymentStatusHandler(mockContext, mockCliConfig)
+                            .handleRequest(request);
+            assertEquals(deploymentId, response.getDeployment().getDeploymentId());
+            assertEquals(DeploymentStatus.FAILED, response.getDeployment().getStatus());
+            assertEquals(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE.toString(),
+                    response.getDeployment().getDeploymentStatusDetails().getDetailedDeploymentStatus().toString());
+            List<String> deploymentErrorStack = response.getDeployment().getDeploymentStatusDetails()
+                    .getDeploymentErrorStack();
+            assertEquals(Arrays.asList("ERROR_STACK_1", "ERROR_STACK_2", "ERROR_STACK_3"),
+                    response.getDeployment().getDeploymentStatusDetails().getDeploymentErrorStack());
+            assertEquals(Collections.singletonList("ERROR_TYPE_1"),
+                    response.getDeployment().getDeploymentStatusDetails().getDeploymentErrorTypes());
+            assertEquals("FAILURE_CAUSE", response.getDeployment().getDeploymentStatusDetails().getDeploymentFailureCause());
+        }
+    }
+
+    @Test
     @SuppressWarnings("PMD.CloseResource")
-    void testGetLocalDeploymentStatus_successful() throws IOException {
+    void testGetLocalDeploymentStatus_deployment_in_progress() throws IOException {
         Topics localDeployments = mock(Topics.class);
         Topics mockCliConfig = mock(Topics.class);
         try (Context context = new Context()) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cli deployment list and status commands now have production ready information like detailed deployment status, error codes, etc. which makes the output more consistent with cloud.

Current `status` command behavior:
```
<Deployment ID>: <Deployment Status> [SUCCEEDED, FAILED, IN_PROGRESS, CANCELED] 
```

Proposed behavior:
```
<Deployment ID>: <Deployment Status> [SUCCEEDED, FAILED, IN_PROGRESS, CANCELED] 
Created on: <Date and time in UTC when the deployment was created>
```

In case of a failed deployment, additional fields are
```
Detailed Status: <Detailed Deployment Status> [SUCCESSFUL, FAILED_ROLLBACK_NOT_REQUESTED, etc.]
Deployment Error Stack: [List of errors codes]
Deployment Error Types: [List of error types]
Failure Cause: <Failure cause>
```

Previously, the `Status` field was replaced by `Detailed Status` completely in case the deployment had completed (not `IN_PROGRESS`). `Status Details` [SUCCESSFUL, FAILED_ROLLBACK_NOT_REQUESTED, etc.] is a different object from `Status` which would have made new Cli version backward incompatible with previous versions.
Fix: Keep the `Status` object as part of the status command output. Populate the `Detailed Status` object only when the deployment fails for some reason.

**Why is this change necessary:**
Till now, Cli deployment command response was minimal and not consistent with cloud (not ready for prod)

**How was this change tested:**
Change was tested with manual verification and unit tests. Also manually verified Nucleus and Cli upgrade downgrade scenario.

    Started with Nucleus and Cli 2.8.1 and verified Cli command outputs
    Upgraded Nucleus and Cli to latest (with proposed changes) and verified Cli command outputs
    Downgraded Nucleus and Cli back to 2.8.1 and verified Cli command outputs
Also, tested with E2E UATs such that changes do not inject any backwards incompatibility

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
