### PR TITLE
chore: add null check for detailed deployment status

### DIFF
--- a/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
+++ b/client/src/main/java/com/aws/greengrass/cli/commands/DeploymentCommand.java
@@ -179,8 +179,11 @@ public class DeploymentCommand extends BaseCommand {
         if (DeploymentStatus.FAILED.equals(deploymentStatus)) {
             DeploymentStatusDetails deploymentStatusDetails = status.getDeploymentStatusDetails();
             if (deploymentStatusDetails != null) {
-                statusBuilder.append(String.format("Detailed Status: %s\n",
-                        deploymentStatusDetails.getDetailedDeploymentStatusAsString()));
+                if (deploymentStatusDetails.getDetailedDeploymentStatusAsString() != null &&
+                        !deploymentStatusDetails.getDetailedDeploymentStatusAsString().trim().isEmpty()) {
+                    statusBuilder.append(String.format("Detailed Status: %s\n",
+                            deploymentStatusDetails.getDetailedDeploymentStatusAsString()));
+                }
                 if (deploymentStatusDetails.getDeploymentErrorStack() != null &&
                         !deploymentStatusDetails.getDeploymentErrorStack().isEmpty()) {
                     statusBuilder.append(String.format("Deployment Error Stack: %s\n",

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -687,8 +687,11 @@ public class CLIEventStreamAgent {
                                 deployment.findTopics(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
                         DeploymentStatusDetails deploymentStatusDetails = new DeploymentStatusDetails();
                         DetailedDeploymentStatus detailedDeploymentStatus = detailedDeploymentStatusFromString(
-                                Coerce.toString(deploymentStatusDetailsTopics.find(DEPLOYMENT_DETAILED_STATUS_KEY)));
-                        deploymentStatusDetails.setDetailedDeploymentStatus(detailedDeploymentStatus);
+                                Coerce.toString(deploymentStatusDetailsTopics
+                                        .find(DEPLOYMENT_DETAILED_STATUS_KEY)));
+                        if (detailedDeploymentStatus != null) {
+                            deploymentStatusDetails.setDetailedDeploymentStatus(detailedDeploymentStatus);
+                        }
                         if (deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_STACK_KEY) != null) {
                             deploymentStatusDetails.setDeploymentErrorStack(Coerce.toStringList(
                                     deploymentStatusDetailsTopics.find(DEPLOYMENT_ERROR_STACK_KEY)));
@@ -842,6 +845,9 @@ public class CLIEventStreamAgent {
     }
 
     private DetailedDeploymentStatus detailedDeploymentStatusFromString(String detailedDeploymentStatus) {
+        if (detailedDeploymentStatus == null || detailedDeploymentStatus.trim().isEmpty()) {
+            return null;
+        }
         for (DetailedDeploymentStatus ds : DetailedDeploymentStatus.values()) {
             if (ds.getValue().equals(detailedDeploymentStatus.toUpperCase())) {
                 return ds;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add null checks for `detailedDeploymentStatus` field before converting to upper case and setting in `DeploymentStatusDetails` object.

**Why is this change necessary:**
When a deployment transitions into the IN_PROGRESS state, Nucleus publishes this state change but populates the `DeploymentStatusDetails` with an empty hash map causing the `detailedDeploymentStatus` field to be null. Additional null and empty checks need to be set in place before this field can be used by CLI.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
