### PR TITLE
fix: reject invalid thing group names

### DIFF
--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -463,7 +463,6 @@ public class CLIEventStreamAgent {
                         .resource(AuthorizationHandler.ANY_REGEX)
                         .operation(CREATE_LOCAL_DEPLOYMENT)
                         .build());
-                String deploymentId = UUID.randomUUID().toString();
                 //All inputs are valid. If all inputs are empty, then user might just want to retrigger the deployment
                 // with new recipes set using the updateRecipesAndArtifacts API.
                 Map<String, ConfigurationUpdateOperation> configUpdate = null;
@@ -493,6 +492,7 @@ public class CLIEventStreamAgent {
                     throw new InvalidArgumentsError("Thing group name cannot contain colon characters");
                 }
 
+                String deploymentId = UUID.randomUUID().toString();
                 LocalOverrideRequest localOverrideRequest = LocalOverrideRequest.builder().requestId(deploymentId)
                         .componentsToMerge(request.getRootComponentVersionsToAdd())
                         .componentsToRemove(request.getRootComponentsToRemove())

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -489,6 +489,10 @@ public class CLIEventStreamAgent {
                     }
                 }
 
+                if (request.getGroupName().contains(":")) {
+                    throw new InvalidArgumentsError("Thing group name cannot contain colon characters");
+                }
+
                 LocalOverrideRequest localOverrideRequest = LocalOverrideRequest.builder().requestId(deploymentId)
                         .componentsToMerge(request.getRootComponentVersionsToAdd())
                         .componentsToRemove(request.getRootComponentsToRemove())

--- a/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIEventStreamAgent.java
@@ -488,9 +488,7 @@ public class CLIEventStreamAgent {
                     }
                 }
 
-                if (request.getGroupName().contains(":")) {
-                    throw new InvalidArgumentsError("Thing group name cannot contain colon characters");
-                }
+                validateThingGroupName(request);
 
                 String deploymentId = UUID.randomUUID().toString();
                 LocalOverrideRequest localOverrideRequest = LocalOverrideRequest.builder().requestId(deploymentId)
@@ -541,6 +539,11 @@ public class CLIEventStreamAgent {
             });
         }
 
+        private void validateThingGroupName(CreateLocalDeploymentRequest request) {
+            if (!Utils.isEmpty(request.getGroupName()) && request.getGroupName().contains(":")) {
+                throw new InvalidArgumentsError("Thing group name cannot contain colon characters");
+            }
+        }
 
         @Override
         public void handleStreamEvent(EventStreamJsonMessage streamRequestEvent) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Reject create deployment requests that contain an invalid thing group name (e.g. contains a `:`).

**Why is this change necessary:**

**How was this change tested:**
Server tests added

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
