### PR TITLE
chore: bump device sdk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: mvn -U -ntp clean verify
         if: matrix.os != 'windows-latest'
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report ${{ matrix.os }}
@@ -43,13 +43,13 @@ jobs:
           python3 ./.github/scripts/cover2cover.py server/target/jacoco-report/jacoco.xml src/main/java > server/target/jacoco-report/cobertura.xml
         if: matrix.os == 'ubuntu-latest'
       - name: Upload Client Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Client Coverage Report
           path: client/target/jacoco-report
       - name: Upload Server Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Server Coverage Report
@@ -65,7 +65,7 @@ jobs:
           cp server/target/jacoco-report/cobertura.xml ./pr/server/jacoco-report/cobertura.xml
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.17.0-CLUSTER-SNAPSHOT</version>
+            <version>1.23.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Issue https://github.com/awslabs/aws-crt-java/issues/737 fixed in CRT v0.30.3
Java IoT Device SDK  includes this CRT version or above from v1.23.0: https://github.com/aws/aws-iot-device-sdk-java-v2/tree/v1.23.0. 

Our latest nucleus already uses this version. Bump the client sdk version in CLI to use the same. 

**Why is this change necessary:**

**How was this change tested:**



**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
