### PR TITLE
fix: restart on auth change rather than reinstall

### DIFF
--- a/server/src/main/java/com/aws/greengrass/cli/CLIService.java
+++ b/server/src/main/java/com/aws/greengrass/cli/CLIService.java
@@ -134,10 +134,10 @@ public class CLIService extends PluginService {
 
 
         config.lookup(CONFIGURATION_CONFIG_KEY, AUTHORIZED_POSIX_GROUPS).subscribe((why, newv) -> {
-            requestReinstall();
+            requestRestart();
         });
         config.lookup(CONFIGURATION_CONFIG_KEY, AUTHORIZED_WINDOWS_GROUPS).subscribe((why, newv) -> {
-            requestReinstall();
+            requestRestart();
         });
     }
 


### PR DESCRIPTION
**Issue #, if available:**
P213048579

**Description of changes:**
Restart the CLI component on auth change, rather than reinstall. 

Restart is needed because the auth is read once on startup and then cached in memory for the rest of the running phase.

Reinstall is not needed because the install phase only installs the CLI client executable, which is not changed by changes in auth.

**Why is this change necessary:**
Prevent unnecessary component reinstalls. For example, during the rollback of a deployment which installed the CLI, the configuration for the CLI is removed, notifying all subscriptions inside of the component, including these two.

**How was this change tested:**
Unit tested

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
